### PR TITLE
Clear protosearch widget form inputs when clear btn is pressed.

### DIFF
--- a/public/app/widgets/protosearch-widget/widget/controllers/protosearch-widget.controller.js
+++ b/public/app/widgets/protosearch-widget/widget/controllers/protosearch-widget.controller.js
@@ -191,6 +191,11 @@ class ProtosearchWidget {
   clearSearchForm() {
     this.UserProfile.profileScope.search = {};
     this.UserProfile.setProfile('search', this.newObject);
+    this._nullifyObjectKeys(this.newObject);
+  }
+
+  _nullifyObjectKeys(obj) {
+    Object.keys(obj).forEach(key => obj[key] = null);
   }
 
   processSearchResult(type) {


### PR DESCRIPTION
This closes #6 
@lmangani @adubovikov please check if this fix solved the issue.