### PR TITLE
Update uigid table if there is no data found. The table is empty in t…

### DIFF
--- a/public/app/search/call-search/controllers/call-search.controller.js
+++ b/public/app/search/call-search/controllers/call-search.controller.js
@@ -145,23 +145,19 @@ class SearchCall {
       const response = await this.SearchService.searchCallByParam(query);
 
       const { data, keys } = response;
-      /* displayName: this.$filter('translate')('hepic.pages.results.'+v) ? this.$filter('translate')('hepic.pages.results.'+v) : v,*/
 
       if (isArray(keys) && !isEmpty(keys)) {
         this.gridOpts.columnDefs = this.getUiGridColumnDefs(keys);
         this.gridApi.core.notifyDataChange(this.uiGridConstants.dataChange.ALL);
+        await this.restoreUiGridState();
       }
 
-      if (isArray(data) && !isEmpty(data)) {
-        this.count = data.length;
-        this.gridOpts.data = data;
-        this.data = data;
-        this.$timeout(() => {
-          angular.element(this.$window).resize();
-        }, 200);
-      }
+      this.gridOpts.data = data;
+      this.data = data;
 
-      await this.restoreUiGridState();
+      this.$timeout(() => {
+        angular.element(this.$window).resize();
+      }, 200);
     } catch (err) {
       this.log.error(err);
     }


### PR DESCRIPTION
…his case.
This closes #27 
The problem was not the timepicker or timemachine. The problem was that if there were no NEW data, the table held the OLD data from the previous successful search. This is very confusing because you select a time range when there are no data but see some old data from the previous time range.