### PR TITLE
Use node:8-alpine in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 # HOMER 7.0.x UI+API
-FROM node:8
+FROM node:8-alpine
+
+RUN apk add --no-cache git
 
 # BUILD FORCE
 ENV BUILD 703053


### PR DESCRIPTION
The size is still horrible but at least 314mb less horrible.

https://hub.docker.com/r/negbie/homer-app/tags -----------------> 176 MB
https://hub.docker.com/r/sipcapture/homer-app/tags ------------> 490 MB

Another thing I dislike:

added 1930 packages from 1430 contributors and audited 14164 packages in 46.894s
found 34 vulnerabilities (16 low, 14 moderate, 4 high)
  run `npm audit fix` to fix them, or `npm audit` for details
