### PR TITLE
Fix HTTP_PORT and HTTPS_PORT replacement

### DIFF
--- a/docker/docker-entrypoint.d/00-sed_files.sh
+++ b/docker/docker-entrypoint.d/00-sed_files.sh
@@ -14,9 +14,9 @@ if [ -f /app/server/config.js ]; then
    if [ -n "$TIMEZONE" ]; then sed -i "s/timezone: 'utc'/timezone: '${TIMEZONE}'/g" /app/server/config.js; fi
    
    if [ -n "$HTTP_HOST" ]; then sed -i "s/http_host: '0.0.0.0'/http_host: '${HTTP_HOST}'/g" /app/server/config.js; fi
-   if [ -n "$HTTP_PORT" ]; then sed -i "s/http_port: 80/http_port: {$HTTP_PORT}/g" /app/server/config.js; fi
+   if [ -n "$HTTP_PORT" ]; then sed -i "s/http_port: 80/http_port: ${HTTP_PORT}/g" /app/server/config.js; fi
    if [ -n "$HTTPS_HOST" ]; then sed -i "s/https_host: '0.0.0.0'/https_host: '${HTTPS_HOST}'/g" /app/server/config.js; fi
-   if [ -n "$HTTPS_PORT" ]; then sed -i "s/https_port: 443/https_port: {$HTTPS_PORT}/g" /app/server/config.js; fi
+   if [ -n "$HTTPS_PORT" ]; then sed -i "s/https_port: 443/https_port: ${HTTPS_PORT}/g" /app/server/config.js; fi
     
    echo "Pre-Flight provisioning completed!"
 


### PR DESCRIPTION
If the ports were changed via environment variables the generated configuration was invalid. The new port values were wrapped inside {} due to an incorrect variable expresssion.