### PR TITLE
Export call data as pcap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ server/config.js
 *.iml
 .idea
 out
+
+# direnv and nix-shell
+.envrc
+default.nix
+.direnv.*

--- a/server/routes/export.js
+++ b/server/routes/export.js
@@ -4,6 +4,7 @@ import SearchData from '../classes/searchdata';
 import Settings from '../classes/settings';
 import PcapBuffer from '../classes/pcap/index';
 import TextBuffer from '../classes/pcap/textbuffer';
+import Alias from '../classes/alias';
 
 
 export default function search(server) {
@@ -140,4 +141,71 @@ export default function search(server) {
       };
     },
   });
+
+  server.route({
+    path: '/api/v3/export/call/data/pcap',
+    method: 'POST',
+    config: {
+      validate: {
+        payload: {
+          param: {
+            id: Joi.object(),
+            transaction: Joi.object(),
+            limit: Joi.number().integer().min(0),
+            location: Joi.object(),
+            search: Joi.object(),
+            timezone: Joi.object(),
+          },
+          timestamp: {
+            from: Joi.date().timestamp().required(),
+            to: Joi.date().timestamp().required(),
+          },
+        },
+      },
+    },
+    handler: async function(request, reply) {
+      const aliasDB = new Alias({server});
+      const aliasRowData = await aliasDB.getAll(['guid', 'alias', 'ip', 'port', 'mask', 'captureID', 'status']);
+      const aliasData = {};
+      aliasRowData.forEach(function(row) {
+            aliasData[row.ip+":"+row.port] = row.alias;
+      });
+
+      console.log("AAL", aliasData);
+
+      const searchdata = new SearchData(server, request.payload.param);
+      const searchTable = 'hep_proto_1_default';
+      try {
+        const data = await searchdata.getSearchData(
+          ['id', 'sid', 'protocol_header', 'data_header', 'raw'],
+          searchTable, request.payload, aliasData
+        );
+        if (!data) {
+          return reply(Boom.notFound('data was not found'));
+        }
+
+        let pcapBuffer = new PcapBuffer(1500, 1);
+
+        data.data.forEach(function(row) {
+          pcapBuffer.writePacket({
+            protocol: row.protocol,
+            sourceIp: row.srcIp,
+            sourcePort: row.srcPort,
+            destinationIp: row.dstIp,
+            destinationPort: row.dstPort,
+            data: row.raw,
+            timestamp: (row.timeSeconds * 1000 + row.timeUseconds*10),
+          });
+        });
+
+        return reply(pcapBuffer.getPacketsAndClose())
+          .encoding('binary')
+          .type('application/cap')
+          .header('content-disposition', `attachment; filename=export-${new Date().toISOString()}.pcap;`);
+      } catch (error) {
+        return reply(Boom.serverUnavailable(error));
+      }
+    },
+  });
+
 };


### PR DESCRIPTION
This PR adds an API endpoint to export search results in the pcap format. We use this feature in Homer 5 and need this to be able to switch to Homer 7.

fixes #143