### PR TITLE
fix migration script

### DIFF
--- a/migrations/20191126194600_Datastructure.js
+++ b/migrations/20191126194600_Datastructure.js
@@ -1,145 +1,205 @@
-
 exports.up = function(knex) {
-  return knex
-    .schema
-    .hasTable('users', (exists) => {
-	if (!exists) {
-	    knex.schema.createTable('users', function(usersTable) {
-	      // Primary Key
-	      usersTable.increments();
-	      // Data
-	      usersTable.string('username', 50).notNullable().unique();
-	      usersTable.integer('partid').notNullable().defaultTo(10);
-	      usersTable.string('email', 250).notNullable();
-	      usersTable.string('firstname', 50).notNullable();
-	      usersTable.string('lastname', 50).notNullable();
-	      usersTable.string('department', 50).notNullable().defaultTo('NOC');
-	      usersTable.string('usergroup', 250).notNullable();
-	      usersTable.string('hash', 128).notNullable();
-	      usersTable.string('guid', 50).notNullable().unique();
-	      usersTable.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
-	    })
-	}
+  return Promise.all([
+    new Promise((resolve, reject) => {
+      knex.schema.hasTable("users").then(exists => {
+        if (!exists) {
+          return knex.schema
+            .createTable("users", function(usersTable) {
+              // Primary Key
+              usersTable.increments();
+              // Data
+              usersTable.string("username", 50).notNullable().unique();
+              usersTable.integer("partid").notNullable().defaultTo(10);
+              usersTable.string("email", 250).notNullable();
+              usersTable.string("firstname", 50).notNullable();
+              usersTable.string("lastname", 50).notNullable();
+              usersTable.string("department", 50).notNullable().defaultTo("NOC");
+              usersTable.string("usergroup", 250).notNullable();
+              usersTable.string("hash", 128).notNullable();
+              usersTable.string("guid", 50).notNullable().unique();
+              usersTable.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+            })
+            .then(resolve)
+            .catch(reject);
+        } else {
+          resolve();
+        }
+      });
+    }),
+
+    new Promise((resolve, reject) => {
+      knex.schema.hasTable("mapping_schema").then(exists => {
+        if (!exists) {
+          return knex.schema
+            .createTable("mapping_schema", function(mappingTable) {
+              // Primary Key
+              mappingTable.increments();
+              // Data
+              mappingTable.uuid("guid");
+              mappingTable.string("profile", 100).notNullable().defaultTo("default");
+              mappingTable.integer("hepid").notNullable();
+              mappingTable.string("hep_alias", 100);
+              mappingTable.integer("partid").notNullable().defaultTo(10);
+              mappingTable.integer("version").notNullable();
+              mappingTable.integer("retention").notNullable().defaultTo(14);
+              mappingTable.integer("partition_step").notNullable().defaultTo(3600);
+              mappingTable.json("create_index");
+              mappingTable.text("create_table");
+              mappingTable.json("correlation_mapping");
+              mappingTable.json("fields_mapping");
+              mappingTable.json("mapping_settings");
+              mappingTable.json("schema_mapping");
+              mappingTable.json("schema_settings");
+              mappingTable.timestamp("create_date").notNullable().defaultTo(knex.fn.now());
+            })
+            .then(resolve)
+            .catch(reject);
+        } else {
+          resolve();
+        }
+      });
+    }),
+
+    new Promise((resolve, reject) => {
+      knex.schema.hasTable("hepsub_mapping_schema").then(exists => {
+        if (!exists) {
+          return knex.schema
+            .createTable("hepsub_mapping_schema", function(hepSubMappingTable) {
+              // Primary Key
+              hepSubMappingTable.increments();
+              // Data
+              hepSubMappingTable.uuid("guid");
+              hepSubMappingTable.string("profile", 100).notNullable().defaultTo("default");
+              hepSubMappingTable.integer("hepid").notNullable();
+              hepSubMappingTable.string("hep_alias", 100);
+              hepSubMappingTable.integer("version").notNullable();
+              hepSubMappingTable.json("mapping");
+              hepSubMappingTable.timestamp("create_date").notNullable().defaultTo(knex.fn.now());
+            })
+            .then(resolve)
+            .catch(reject);
+        } else {
+          resolve();
+        }
+      });
+    }),
+
+    new Promise((resolve, reject) => {
+      knex.schema.hasTable("user_settings").then(exists => {
+        if (!exists) {
+          return knex.schema
+            .createTable("user_settings", function(userSettingsTable) {
+              // Primary Key
+              userSettingsTable.increments();
+              // Data
+              userSettingsTable.uuid("guid");
+              userSettingsTable.string("username", 100).notNullable();
+              userSettingsTable.integer("partid").notNullable();
+              userSettingsTable.string("category", 100).notNullable().defaultTo("settings");
+              userSettingsTable.timestamp("create_date").notNullable().defaultTo(knex.fn.now());
+              userSettingsTable.string("param", 100).notNullable().defaultTo("default");
+              userSettingsTable.json("data");
+            })
+            .then(resolve)
+            .catch(reject);
+        } else {
+          resolve();
+        }
+      });
+    }),
+
+    new Promise((resolve, reject) => {
+      knex.schema.hasTable("global_settings").then(exists => {
+        if (!exists) {
+          return knex.schema
+            .createTable("global_settings", function(globalSettingsTable) {
+              // Primary Key
+              globalSettingsTable.increments();
+              // Data
+              globalSettingsTable.uuid("guid");
+              globalSettingsTable.integer("partid").notNullable();
+              globalSettingsTable.string("category", 100).notNullable().defaultTo("settings");
+              globalSettingsTable.timestamp("create_date").notNullable().defaultTo(knex.fn.now());
+              globalSettingsTable.string("param", 100).notNullable().defaultTo("default");
+              globalSettingsTable.json("data");
+            })
+            .then(resolve)
+            .catch(reject);
+        } else {
+          resolve();
+        }
+      });
+    }),
+
+    new Promise((resolve, reject) => {
+      knex.schema.hasTable("agent_location_session").then(exists => {
+        if (!exists) {
+          return knex.schema
+            .createTable("agent_location_session", function(
+              agentLocationSession
+            ) {
+              // Primary Key
+              agentLocationSession.increments();
+              // Data
+              agentLocationSession.uuid("guid");
+              agentLocationSession.integer("gid").notNullable();
+              agentLocationSession.string("host", 250).notNullable().defaultTo("127.0.0.1");
+              agentLocationSession.integer("port").notNullable().defaultTo(8080);
+              agentLocationSession.string("protocol", 50).notNullable().defaultTo("log");
+              agentLocationSession.string("path", 250).notNullable().defaultTo("/api/search");
+              agentLocationSession.string("node", 100).notNullable().defaultTo("testnode");
+              agentLocationSession.string("type", 200).notNullable().defaultTo("type");
+              agentLocationSession.timestamp("create_date").notNullable().defaultTo(knex.fn.now());
+              agentLocationSession.timestamp("expire_date").notNullable().defaultTo(
+                  knex.raw("? + (? * interval '1 second')", [
+                    knex.fn.now(),
+                    "86400"
+                  ])
+                );
+              agentLocationSession.integer("active").notNullable().defaultTo(1);
+            })
+            .then(resolve)
+            .catch(reject);
+        } else {
+          resolve();
+        }
+      });
+    }),
+
+    new Promise((resolve, reject) => {
+      knex.schema.hasTable("alias").then(exists => {
+        if (!exists) {
+          return knex.schema
+            .createTable("alias", function(aliasTable) {
+              // Primary Key
+              aliasTable.increments();
+              // Data
+              aliasTable.uuid("guid");
+              aliasTable.string("alias", 40);
+              aliasTable.string("ip", 60);
+              aliasTable.integer("port");
+              aliasTable.integer("mask");
+              aliasTable.string("captureID", 20);
+              aliasTable.boolean("status");
+              aliasTable.timestamp("create_date").notNullable().defaultTo(knex.fn.now());
+            })
+            .then(resolve)
+            .catch(reject);
+        } else {
+          resolve();
+        }
+      });
     })
-    .hasTable('mapping_schema', (exists) => {
-	if (!exists) {
-	    knex.schema.createTable('mapping_schema', function(mappingTable) {
-	      // Primary Key
-	      mappingTable.increments();
-	      // Data
-	      mappingTable.uuid('guid');
-	      mappingTable.string('profile', 100).notNullable().defaultTo('default');
-	      mappingTable.integer('hepid').notNullable();
-	      mappingTable.string('hep_alias', 100);
-	      mappingTable.integer('partid').notNullable().defaultTo(10);
-	      mappingTable.integer('version').notNullable();
-	      mappingTable.integer('retention').notNullable().defaultTo(14);
-	      mappingTable.integer('partition_step').notNullable().defaultTo(3600);
-	      mappingTable.json('create_index');
-	      mappingTable.text('create_table');
-	      mappingTable.json('correlation_mapping');
-	      mappingTable.json('fields_mapping');
-	      mappingTable.json('mapping_settings');
-	      mappingTable.json('schema_mapping');
-	      mappingTable.json('schema_settings');
-	      mappingTable.timestamp('create_date').notNullable().defaultTo(knex.fn.now());
-	    })
-	}
-    })
-    .hasTable('hepsub_mapping_schema', (exists) => {
-	if (!exists) {
-	    knex.schema.createTable('hepsub_mapping_schema', function(hepSubMappingTable) {
-	      // Primary Key
-	      hepSubMappingTable.increments();
-	      // Data
-	      hepSubMappingTable.uuid('guid');
-	      hepSubMappingTable.string('profile', 100).notNullable().defaultTo('default');
-	      hepSubMappingTable.integer('hepid').notNullable();
-	      hepSubMappingTable.string('hep_alias', 100);
-	      hepSubMappingTable.integer('version').notNullable();
-	      hepSubMappingTable.json('mapping');
-	      hepSubMappingTable.timestamp('create_date').notNullable().defaultTo(knex.fn.now());
-	    })
-	}
-    })
-    .hasTable('user_settings', (exists) => {
-		if (!exists) {
-	    knex.schema.createTable('user_settings', function(userSettingsTable) {
-	      // Primary Key
-	      userSettingsTable.increments();
-	      // Data
-	      userSettingsTable.uuid('guid');
-	      userSettingsTable.string('username', 100).notNullable();
-	      userSettingsTable.integer('partid').notNullable();
-	      userSettingsTable.string('category', 100).notNullable().defaultTo('settings');
-	      userSettingsTable.timestamp('create_date').notNullable().defaultTo(knex.fn.now());
-	      userSettingsTable.string('param', 100).notNullable().defaultTo('default');
-	      userSettingsTable.json('data');
-	    })
-	}
-    })
-    .hasTable('global_settings', (exists) => {
-	if (!exists) {
-	    knex.schema.createTable('global_settings', function(globalSettingsTable) {
-	      // Primary Key
-	      globalSettingsTable.increments();
-	      // Data
-	      globalSettingsTable.uuid('guid');
-	      globalSettingsTable.integer('partid').notNullable();
-	      globalSettingsTable.string('category', 100).notNullable().defaultTo('settings');
-	      globalSettingsTable.timestamp('create_date').notNullable().defaultTo(knex.fn.now());
-	      globalSettingsTable.string('param', 100).notNullable().defaultTo('default');
-	      globalSettingsTable.json('data');
-	    })
-	}
-    })
-    .hasTable('agent_location_session', (exists) => {
-	if (!exists) {
-	    knex.schema.createTable('agent_location_session', function(agentLocationSession) {
-	      // Primary Key
-	      agentLocationSession.increments();
-	      // Data
-	      agentLocationSession.uuid('guid');
-	      agentLocationSession.integer('gid').notNullable();
-	      agentLocationSession.string('host', 250).notNullable().defaultTo('127.0.0.1');
-	      agentLocationSession.integer('port').notNullable().defaultTo(8080);
-	      agentLocationSession.string('protocol', 50).notNullable().defaultTo('log');
-	      agentLocationSession.string('path', 250).notNullable().defaultTo('/api/search');
-	      agentLocationSession.string('node', 100).notNullable().defaultTo('testnode');
-	      agentLocationSession.string('type', 200).notNullable().defaultTo('type');
-	      agentLocationSession.timestamp('create_date').notNullable().defaultTo(knex.fn.now());
-	      agentLocationSession.timestamp('expire_date').notNullable().defaultTo(knex.raw('? + (? * interval \'1 second\')', [knex.fn.now(), "86400"]));
-	      agentLocationSession.integer('active').notNullable().defaultTo(1);
-	    })
-	}
-    })
-    .hasTable('alias', (exists) => {
-	if (!exists) {
-	    knex.schema.createTable('alias', function(aliasTable) {
-	      // Primary Key
-	      aliasTable.increments();
-	      // Data
-	      aliasTable.uuid('guid');
-	      aliasTable.string('alias', 40);
-	      aliasTable.string('ip', 60);
-	      aliasTable.integer('port');
-	      aliasTable.integer('mask');
-	      aliasTable.string('captureID', 20);
-	      aliasTable.boolean('status');
-	      aliasTable.timestamp('create_date').notNullable().defaultTo(knex.fn.now());
-	    })
-	}
-    });
+  ]);
 };
 
 exports.down = function(knex) {
-  return knex
-    .schema
-    .dropTableIfExists( 'mapping_schema' )
-    .dropTableIfExists( 'hepsub_mapping_schema' )
-    .dropTableIfExists( 'user_settings' )
-    .dropTableIfExists( 'global_settings' )
-    .dropTableIfExists( 'agent_location_session' )
-    .dropTableIfExists( 'alias' )
-    .dropTableIfExists( 'users' );
+  return knex.schema
+    .dropTableIfExists("mapping_schema")
+    .dropTableIfExists("hepsub_mapping_schema")
+    .dropTableIfExists("user_settings")
+    .dropTableIfExists("global_settings")
+    .dropTableIfExists("agent_location_session")
+    .dropTableIfExists("alias")
+    .dropTableIfExists("users");
 };


### PR DESCRIPTION
This PR 
- makes the knex migrations promised based
- throws errors if the migration cannot run  (for example ensuring that the error referenced [here](https://github.com/sipcapture/homer-app/issues/217#issuecomment-571767054) is thrown, not swallowed, by knex:migrate)
- and make sure knex:migrate doesn't die before tables are built

In the previous version of this migrate script, I noticed that if I put `console.log(exists)` right before the `if (!exists)` line, the value of `exists` wouldn't output to the terminal -- because the migration script didn't actually wait for the code inside of `hasTable` to run. This PR makes sure that the promises tied to both `hasTable` and `createTable` are returned. 

Additionally, when I ran the previous version of this migration script, my version of postgresql didn't like the `knex.fn.now(), + 86400` code, but the error was swallowed because the script finished running before the error could be thrown -- and the migration incorrectly appeared to complete successfully. This change makes sure that when the tables are not able to be created, the migration will not successfully complete, and an error will be properly thrown.