### PR TITLE
Add toggle to prevent appending the DN to the username

### DIFF
--- a/server/classes/ldap.js
+++ b/server/classes/ldap.js
@@ -49,7 +49,10 @@ class LdapAuth {
                   };
 	
                   let userDN = this.ldapAuth.userdn.replace("%USERNAME\%", this.username);
-                  let dnRetrieved =  userDN + ',' + this.ldapAuth.dn;
+                  let dnRetrieved = userDN;
+                  if (typeof this.ldapAuth.appendDN == 'undefined' || this.ldapAuth.appendDN) {
+                          dnRetrieved = dnRetrieved + ',' + this.ldapAuth.dn;
+                  }
 
                   let that = this;
 

--- a/server/config.js
+++ b/server/config.js
@@ -57,6 +57,7 @@ const proxyConfig = {
 const ldapauth = {
    url: 'ldap://127.0.0.1:389',
    strictDN: true,
+   appendDN: true,
    dn: 'dc=qxip,dc=net',
    userdn: 'uid=%USERNAME%',
    filter: '(uid=%USERNAME%)',


### PR DESCRIPTION
**Background information**

We use Microsoft AD in our network to authenticate our users. While configuring LDAP authentication in Homer we ran into a limitation. In the current situation, it's only possible to bind to the AD using a distinguished name (DN). As far as I know, in Microsoft AD it's only possible to use the common name (CN) in the DN. In most cases, the CN is the full name of the user. Therefore, the full DN might look like `CN=John Doe,OU=Users,DC=contoso,DC=com`.

Instead of using the DN, we would like to use the user principal name (UPN) during authentication. In the current implementation, this is not possible since [this line](https://github.com/sipcapture/homer-app/blob/master/server/classes/ldap.js#L52) always appends the DN to the username. You can't leave the DN empty since it leaves a comma and it's needed [later on](https://github.com/sipcapture/homer-app/blob/master/server/classes/ldap.js#L94) during the search request.

**Changes**

This pull requests adds a toggle to prevent appending the DN to the username during LDAP authentication. This makes it possible to use [other name forms](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6a5891b8-928e-4b75-a4a5-0e3b77eaca52) during authentication when you use Microsoft Active Directory, such as the user principal name (UPN).

To keep backwards compatibility, the toggle defaults to `true` when its not set in the `config.js` file.

**Example config**

Here an example config to get UPN working with this pull request.

```
const ldapauth = {
   url: 'ldaps://dc01.ad.contoso.com:636',
   strictDN: true,
   appendDN: false,
   dn: 'OU=Users,DC=ad,DC=contoso,DC=com',
   userdn: '%USERNAME%',
   # userdn: '%USERNAME%@ad.contoso.com', # With a default domain
   filter: '(sAMAccountName=%USERNAME%)',
   scope: 'sub',
   uidNumber: 'objectGUID'
}
```

Please excuse me if there is already a way to do this, I've searched the closed issues but they all seemed to be about configuring LDAP with OpenLDAP, and I'm not really familiar with how OpenLDAP works. The default `userdn` value of `uid=%USERNAME%` kept resulting in a `NT_STATUS_NO_SUCH_USER` from our AD.