### PR TITLE
Add logic to be able to supply DB_KEEPALIVE and HOMER_LOGLEVEL to Homer.

### DIFF
--- a/docker/docker-entrypoint.d/1
+++ b/docker/docker-entrypoint.d/1
@@ -10,6 +10,12 @@ if [ -f /usr/local/homer/etc/webapp_config.json ]; then
    if [ -n "$DB_HOST" ]; then sed -i "s/homer_db_host/${DB_HOST}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$DB_USER" ]; then sed -i "s/homer_user/${DB_USER}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$DB_PASS" ]; then sed -i "s/homer_password/${DB_PASS}/g" /usr/local/homer/etc/webapp_config.json; fi
+
+   if [ -n "$DB_KEEPALIVE" -a "$DB_KEEPALIVE" == "true" ]; then sed -i -e "s/keepalive\":.*$/keepalive\": true,/g" /usr/local/homer/etc/webapp_config.json;
+   else sed -i -e "s/keepalive\":.*$/keepalive\": false,/g" /usr/local/homer/etc/webapp_config.json; fi
+
+   if [ -n "$HOMER_LOGLEVEL" ]; then sed -i "s/homer_loglevel/${HOMER_LOGLEVEL}/g" /usr/local/homer/etc/webapp_config.json; 
+   else sed -i "s/homer_loglevel/error/g" /usr/local/homer/etc/webapp_config.json; fi
    
    if [ -n "$INFLUX_HOST" ]; then sed -i "s/influx_host/${INFLUX_HOST}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$INFLUX_USER" ]; then sed -i "s/influx_user/${INFLUX_USER}/g" /usr/local/homer/etc/webapp_config.json; fi

--- a/docker/webapp_config.json
+++ b/docker/webapp_config.json
@@ -12,7 +12,8 @@
     "user": "homer_user",
     "pass": "homer_password",
     "name": "homer_config",
-    "host": "homer_db_host"
+    "host": "homer_db_host",
+    "keepalive": false,
   },
   "influxdb_config": {
     "user": "influx_user",
@@ -43,7 +44,10 @@
   },
   "system_settings": {
     "logpath": "/usr/local/homer",
-    "logname" : "homer-app.log"
+    "logname" : "homer-app.log",
+    "_loglevels": "can be: fatal, error, warn, info, debug, trace",
+    "loglevel": "homer_loglevel",
+    "logstdout": false
   },
   "auth_settings": {
     "_comment": "The type param can be internal, ldap",


### PR DESCRIPTION
Simply add

* "DB_KEEPALIVE=true"

to the homer-webapp section of docker-compose.yml to enable DB keepalive function

and e.g.
* "HOMER_LOGLEVEL=debug"

to the homer section docker-compose.yml to set specific logging level

Bash script portions and sed expressions tested. 