### PR TITLE
Fix trailing comma which prevents Homer from starting up.

### DIFF
--- a/docker/webapp_config.json
+++ b/docker/webapp_config.json
@@ -13,7 +13,7 @@
     "pass": "homer_password",
     "name": "homer_config",
     "host": "homer_db_host",
-    "keepalive": false,
+    "keepalive": false
   },
   "influxdb_config": {
     "user": "influx_user",


### PR DESCRIPTION
Produces the rather confusing and counter-intuitive error message

No configuration file loaded:  While parsing config: invalid character '}' looking for beginning of object key string

panic: DB configuration file not found

etc