### PR TITLE
Simplify db keepalive startup setting

### DIFF
--- a/docker/docker-entrypoint.d/1
+++ b/docker/docker-entrypoint.d/1
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 DB_HOST=${DB_HOST:-localhost}
+DB_KEEPALIVE=${DB_KEEPALIVE:-false} #default to false
+DB_KEEPALIVE=${DB_KEEPALIVE,,} #set to lower-case
 INFLUX_DB=${INFLUX_DB:-localhost}
 PROM_HOST=${PROM_HOST:-localhost}
 LOKI_HOST=${LOKI_HOST:-localhost}
@@ -10,9 +12,7 @@ if [ -f /usr/local/homer/etc/webapp_config.json ]; then
    if [ -n "$DB_HOST" ]; then sed -i "s/homer_db_host/${DB_HOST}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$DB_USER" ]; then sed -i "s/homer_user/${DB_USER}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$DB_PASS" ]; then sed -i "s/homer_password/${DB_PASS}/g" /usr/local/homer/etc/webapp_config.json; fi
-
-   if [ -n "$DB_KEEPALIVE" -a "$DB_KEEPALIVE" == "true" ]; then sed -i -e "s/keepalive\":.*$/keepalive\": true/g" /usr/local/homer/etc/webapp_config.json;
-   else sed -i -e "s/keepalive\":.*$/keepalive\": false/g" /usr/local/homer/etc/webapp_config.json; fi
+   if [ -n "$DB_KEEPALIVE" ]; then sed -i "s/homer_db_keepalive/${DB_KEEPALIVE}/g" /usr/local/homer/etc/webapp_config.json; fi
 
    if [ -n "$HOMER_LOGLEVEL" ]; then sed -i "s/homer_loglevel/${HOMER_LOGLEVEL}/g" /usr/local/homer/etc/webapp_config.json; 
    else sed -i "s/homer_loglevel/error/g" /usr/local/homer/etc/webapp_config.json; fi

--- a/docker/webapp_config.json
+++ b/docker/webapp_config.json
@@ -13,7 +13,7 @@
     "pass": "homer_password",
     "name": "homer_config",
     "host": "homer_db_host",
-    "keepalive": false
+    "keepalive": homer_db_keepalive
   },
   "influxdb_config": {
     "user": "influx_user",


### PR DESCRIPTION
(i.e. whether a comma follows it or not)

Ensures that the keepalive boolean setting can appear on any row in the block (and optionally have a comma follow it) following later edits. 