### PR TITLE
Allow pulling LDAP groups from any attribute

### DIFF
--- a/data/service/user.go
+++ b/data/service/user.go
@@ -159,9 +159,13 @@ func (us *UserService) LoginUser(username, password string) (string, model.Table
 
 		groups, err := us.LdapClient.GetGroupsOfUser(username)
 		if err != nil {
-			logrus.Error("Couldn't get any group for user: ", username)
+			logrus.Error("Couldn't get any group for user ", username, ": ", err)
 		} else {
-			if heputils.ElementExists(groups, us.LdapClient.AdminGroup) {
+			logrus.Debug("Found groups for user ", username, ": ", groups)
+			// ElementExists returns true if the given slice is empty, so we explicitly check that here
+			// to prevent users with no groups from becoming admins
+			if len(groups) > 0 && heputils.ElementExists(groups, us.LdapClient.AdminGroup) {
+				logrus.Debug("User ", username, " is a member of the admin group ", us.LdapClient.AdminGroup)
 				userData.IsAdmin = true
 			}
 		}

--- a/docker/webapp_config.json
+++ b/docker/webapp_config.json
@@ -1,6 +1,6 @@
 {
   "database_data": {
-    "local":{
+    "local": {
       "node": "LocalNode",
       "user": "homer_user",
       "pass": "homer_password",
@@ -19,7 +19,7 @@
     "user": "influx_user",
     "pass": "influx_pass",
     "name": "homer_config",
-    "host": "http://influx_host:8086" ,
+    "host": "http://influx_host:8086",
     "database": "homer",
     "policy": "autogen"
   },
@@ -37,14 +37,14 @@
   },
   "http_settings": {
     "host": "0.0.0.0",
-    "port" : 80,
-    "root" : "/usr/local/homer/dist",
-    "gzip" : true,
-    "debug" : false
+    "port": 80,
+    "root": "/usr/local/homer/dist",
+    "gzip": true,
+    "debug": false
   },
   "system_settings": {
     "logpath": "/usr/local/homer",
-    "logname" : "homer-app.log",
+    "logname": "homer-app.log",
     "_comment": "loglevel can be: fatal, error, warn, info, debug, trace",
     "loglevel": "homer_loglevel",
     "logstdout": false
@@ -54,14 +54,15 @@
     "type": "internal"
   },
   "ldap_config": {
-    "Base":  "dc=example,dc=com",
-		"Host":  "ldap.example.com",
-		"Port":   389,
-		"UseSSL": false,
-		"BindDN": "uid=readonlysuer,ou=People,dc=example,dc=com",
-		"BindPassword": "readonlypassword",
-		"UserFilter": "(uid=%s)",
-		"GroupFilter": "(memberUid=%s)",
-		"Attributes": "\"givenName\", \"sn\", \"mail\", \"uid\""
+    "Base": "dc=example,dc=com",
+    "Host": "ldap.example.com",
+    "Port": 389,
+    "UseSSL": false,
+    "BindDN": "uid=readonlysuer,ou=People,dc=example,dc=com",
+    "BindPassword": "readonlypassword",
+    "UserFilter": "(uid=%s)",
+    "GroupFilter": "(memberUid=%s)",
+    "GroupAttribute": "cn",
+    "Attributes": "\"givenName\", \"sn\", \"mail\", \"uid\""
   }
 }

--- a/etc/webapp_config.json
+++ b/etc/webapp_config.json
@@ -29,7 +29,7 @@
     "user": "influx_user",
     "pass": "influx_password",
     "name": "homer_config",
-    "host": "http://127.0.0.1:8086" ,
+    "host": "http://127.0.0.1:8086",
     "database": "homer",
     "policy": "autogen"
   },
@@ -51,16 +51,16 @@
   "http_settings": {
     "help": "Settings for the HOMER Webapp Server. If you have gzip_static = false, please be sure that your dist directory has uncompressed .js files",
     "host": "0.0.0.0",
-    "port" : 9080,
-    "root" : "/usr/local/homer/dist",
-    "gzip" : true,
-    "gzip_static" : true,
-    "debug" : false
+    "port": 9080,
+    "root": "/usr/local/homer/dist",
+    "gzip": true,
+    "gzip_static": true,
+    "debug": false
   },
   "system_settings": {
     "help": "Settings for HOMER logs",
     "logpath": "/usr/local/homer/log",
-    "logname" : "homer-app.log",
+    "logname": "homer-app.log",
     "_loglevels": "can be: fatal, error, warn, info, debug, trace",
     "loglevel": "error",
     "logstdout": false
@@ -71,15 +71,16 @@
     "token_expire": 1200
   },
   "ldap_config": {
-    "base":  "dc=example,dc=com",
-		"host":  "ldap.example.com",
-		"port":   389,
+    "base": "dc=example,dc=com",
+    "host": "ldap.example.com",
+    "port": 389,
     "usessl": false,
     "skiptls": true,
-		"binddn": "uid=readonlysuer,ou=People,dc=example,dc=com",
-		"bindpassword": "readonlypassword",
-		"userfilter": "(uid=%s)",
+    "binddn": "uid=readonlysuer,ou=People,dc=example,dc=com",
+    "bindpassword": "readonlypassword",
+    "userfilter": "(uid=%s)",
     "groupfilter": "(memberUid=%s)",
+    "groupattribute": "cn",
     "admingroup": "admin",
     "adminmode": true,
     "attributes": ["givenName", "sn", "mail", "uid"],
@@ -91,6 +92,6 @@
     "_comment": "Here you can do packet decoding to using tshark application. Please define uid, gid if you run the app under root",
     "active": false,
     "bin": "/usr/bin/tshark",
-    "protocols":  ["1_call","1_registration", "1_default"]
+    "protocols": ["1_call", "1_registration", "1_default"]
   }
 }

--- a/main.go
+++ b/main.go
@@ -275,10 +275,16 @@ func main() {
 		ldapClient.BindDN = viper.GetString("ldap_config.binddn")
 		ldapClient.BindPassword = viper.GetString("ldap_config.bindpassword")
 		ldapClient.UserFilter = viper.GetString("ldap_config.userfilter")
-		ldapClient.GroupFilter = viper.GetString("ldap_config.groupfilter")
 		ldapClient.Attributes = viper.GetStringSlice("ldap_config.attributes")
 		ldapClient.AdminGroup = viper.GetString("ldap_config.admingroup")
 		ldapClient.AdminMode = viper.GetBool("ldap_config.adminmode")
+		ldapClient.GroupFilter = viper.GetString("ldap_config.groupfilter")
+		
+		if viper.IsSet("ldap_config.groupattribute") {
+			ldapClient.GroupAttribute = viper.GetString("ldap_config.groupattribute")
+		} else {
+			ldapClient.GroupAttribute = "cn";
+		}
 
 		if viper.IsSet("ldap_config.skiptls") {
 			ldapClient.SkipTLS = viper.GetBool("ldap_config.skiptls")

--- a/utils/ldap/ldap.go
+++ b/utils/ldap/ldap.go
@@ -18,6 +18,7 @@ type LDAPClient struct {
 	BindDN             string
 	BindPassword       string
 	GroupFilter        string // e.g. "(memberUid=%s)"
+	GroupAttribute     string // e.g. "memberOf" / "cn"
 	Host               string
 	ServerName         string
 	UserFilter         string // e.g. "(uid=%s)"
@@ -195,7 +196,7 @@ func (lc *LDAPClient) GetGroupsOfUser(username string) ([]string, error) {
 		lc.Base,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
 		fmt.Sprintf(lc.GroupFilter, username),
-		[]string{"cn"}, // can it be something else than "cn"?
+		[]string{lc.GroupAttribute},
 		nil,
 	)
 	sr, err := lc.Conn.Search(searchRequest)
@@ -204,7 +205,7 @@ func (lc *LDAPClient) GetGroupsOfUser(username string) ([]string, error) {
 	}
 	groups := []string{}
 	for _, entry := range sr.Entries {
-		groups = append(groups, entry.GetAttributeValue("cn"))
+		groups = append(groups, entry.GetAttributeValues(lc.GroupAttribute)...)
 	}
 	return groups, nil
 }


### PR DESCRIPTION
These are all changes I needed to introduce in order to get Homer running with Microsoft AD on Windows. Plus, a few added niceties, like new debug logs, that helped me troubleshoot errors.

Main issue with existing approach is that it both relies on the LDAP user groups query returning **entries with `cn` attributes** and it **only** allows for the value of **`username` to be replaced in the filter template**. While simple to pull off on Open LDAP (i.e. Linux) by means of `memberUid`, default Active Directory installations typically store group memberships on a `member` attribute pointing to a list of fully qualified names, not usernames.

By introducing a new `"groupattribute"` setting, I was able to query groups following:

```json
"groupfilter": "(sAMAccountName=%s)",
"groupattribute": "memberOf",
```

An arguably better approach would have been replacing `Sprintf` with [full templating capabilities](https://golang.org/pkg/text/template/) for `"*filter"` values, enabling string interpolation of any LDAP attribute. In the end, I felt this was simpler.
