### PR TITLE
Kpribic ldap

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -122,6 +122,10 @@ If the loglevel is >= info , the stdout will be enabled automaticaly.
 
 ### Authentication Settings
 This section defines how `homer-app` will authenticate its API and UI users. By default, uses internal database.
+`adminmode` and `usermode` defines privilege level of user that performed successful LDAP bind but didn't match
+any defined group, if both are false login wil fail. If both are true, `adminmode` takes precedece.
+For Active Directory recursive group search use `"groupfilter": "(member:1.2.840.113556.1.4.1941:=%s)"`
+
 ```  
   "auth_settings": {
     "_comment": "The type param can be internal, ldap",
@@ -137,8 +141,11 @@ This section defines how `homer-app` will authenticate its API and UI users. By 
 		"bindpassword": "readonlypassword",
 		"userfilter": "(uid=%s)",
     "groupfilter": "(memberUid=%s)",
-    "admingroup": "admin",
+    "admingroup": "HOMER_admin",
     "adminmode": true,
+    "usergroup": "HOMER_user",
+    "usermode": true,
+
     "attributes": ["givenName", "sn", "mail", "uid"]
   },
 }

--- a/data/service/user.go
+++ b/data/service/user.go
@@ -157,7 +157,7 @@ func (us *UserService) LoginUser(username, password string) (string, model.Table
 			userData.UserGroup = val
 		}
 
-		groups, err := us.LdapClient.GetGroupsOfUser(username)
+		groups, err := us.LdapClient.GetGroupsOfUser(user["dn"])
 		if err != nil {
 			logrus.Error("Couldn't get any group for user ", username, ": ", err)
 		} else {

--- a/etc/webapp_config.json
+++ b/etc/webapp_config.json
@@ -83,7 +83,9 @@
     "groupattribute": "cn",
     "admingroup": "admin",
     "adminmode": true,
-    "attributes": ["givenName", "sn", "mail", "uid"],
+    "usergroup": "HOMER_user",
+    "usermode": true,
+    "attributes": ["dn", "givenName", "sn", "mail", "uid"],
     "skipverify": true,
     "anonymous": false,
     "userdn": "uid=%s,ou=People,dc=example,dc=com"

--- a/main.go
+++ b/main.go
@@ -278,6 +278,8 @@ func main() {
 		ldapClient.Attributes = viper.GetStringSlice("ldap_config.attributes")
 		ldapClient.AdminGroup = viper.GetString("ldap_config.admingroup")
 		ldapClient.AdminMode = viper.GetBool("ldap_config.adminmode")
+		ldapClient.UserGroup = viper.GetString("ldap_config.usergroup")
+		ldapClient.UserMode = viper.GetBool("ldap_config.usermode")
 		ldapClient.GroupFilter = viper.GetString("ldap_config.groupfilter")
 		
 		if viper.IsSet("ldap_config.groupattribute") {

--- a/main.go
+++ b/main.go
@@ -281,11 +281,17 @@ func main() {
 		ldapClient.UserGroup = viper.GetString("ldap_config.usergroup")
 		ldapClient.UserMode = viper.GetBool("ldap_config.usermode")
 		ldapClient.GroupFilter = viper.GetString("ldap_config.groupfilter")
-		
+
+		if viper.IsSet("ldap_config.UseDNForGroupSearch") {
+			ldapClient.UseDNForGroupSearch = viper.GetBool("ldap_config.UseDNForGroupSearch")
+		} else {
+			ldapClient.UseDNForGroupSearch = false
+		}
+
 		if viper.IsSet("ldap_config.groupattribute") {
 			ldapClient.GroupAttribute = viper.GetString("ldap_config.groupattribute")
 		} else {
-			ldapClient.GroupAttribute = "cn";
+			ldapClient.GroupAttribute = "cn"
 		}
 
 		if viper.IsSet("ldap_config.skiptls") {

--- a/utils/ldap/ldap.go
+++ b/utils/ldap/ldap.go
@@ -31,6 +31,8 @@ type LDAPClient struct {
 	SkipTLS            bool
 	AdminGroup         string
 	AdminMode          bool
+	UserGroup          string
+	UserMode           bool
 
 	ClientCertificates []tls.Certificate // Adding client certificates
 }

--- a/utils/ldap/ldap.go
+++ b/utils/ldap/ldap.go
@@ -13,26 +13,27 @@ import (
 )
 
 type LDAPClient struct {
-	Attributes         []string
-	Base               string
-	BindDN             string
-	BindPassword       string
-	GroupFilter        string // e.g. "(memberUid=%s)"
-	GroupAttribute     string // e.g. "memberOf" / "cn"
-	Host               string
-	ServerName         string
-	UserFilter         string // e.g. "(uid=%s)"
-	Conn               *ldap.Conn
-	Port               int
-	InsecureSkipVerify bool
-	UseSSL             bool
-	Anonymous          bool
-	UserDN             string
-	SkipTLS            bool
-	AdminGroup         string
-	AdminMode          bool
-	UserGroup          string
-	UserMode           bool
+	Attributes          []string
+	Base                string
+	BindDN              string
+	BindPassword        string
+	GroupFilter         string // e.g. "(memberUid=%s)"
+	GroupAttribute      string // e.g. "memberOf" / "cn"
+	Host                string
+	ServerName          string
+	UserFilter          string // e.g. "(uid=%s)"
+	Conn                *ldap.Conn
+	Port                int
+	InsecureSkipVerify  bool
+	UseSSL              bool
+	Anonymous           bool
+	UserDN              string
+	SkipTLS             bool
+	AdminGroup          string
+	AdminMode           bool
+	UserGroup           string
+	UserMode            bool
+	UseDNForGroupSearch bool
 
 	ClientCertificates []tls.Certificate // Adding client certificates
 }
@@ -107,7 +108,7 @@ func (lc *LDAPClient) Authenticate(username, password string) (bool, bool, map[s
 		}
 
 		attributes := append(lc.Attributes, "dn")
-		userFilter := fmt.Sprintf(lc.UserFilter, username) 
+		userFilter := fmt.Sprintf(lc.UserFilter, username)
 		// Search for the given username
 		searchRequest := ldap.NewSearchRequest(
 			lc.Base,


### PR DESCRIPTION
Added support for LDAP login as Admin and as User (issue https://github.com/sipcapture/homer-app/issues/328)
This requires changes to webapp conf file, with two new parameters that act similarly to their admin counterparts:
- usergroup
- usermode

Added support for recursive LDAP group search for Microsoft AD. This requred one optional parameter in config that is set by default to false. If set to true homer-app uses dn instead of username for resolving groups, as requred by 1.2.840.113556.1.4.1941 LDAP query.
- UseDNForGroupSearch