### PR TITLE
Filter dup packets in call flow

### DIFF
--- a/data/service/search.go
+++ b/data/service/search.go
@@ -969,7 +969,20 @@ func uniqueHepTable(hepSlice []model.HepTable) []model.HepTable {
 			list = append(list, entry)
 		}
 	}
-	return list
+	logrus.Infoln("Transaction size after first filter:", len(list))
+	keys2 := make(map[string]string)
+	list2 := []model.HepTable{}
+	for _, entry := range list {
+		var protocolHeader map[string]interface{}
+		json.Unmarshal(entry.ProtocolHeader, &protocolHeader)
+		dataKey := entry.Raw
+		if value, exists := keys2[dataKey]; value == protocolHeader["captureId"].(string) || !exists {
+			keys2[dataKey] = protocolHeader["captureId"].(string)
+			list2 = append(list2, entry)
+		}
+	}
+	logrus.Infoln("Transaction size after second filter:", len(list2))
+	return list2
 }
 
 // this method create new user in the database


### PR DESCRIPTION
We've been using homer and noted that when we have several network nodes reporting to a heplify-server cluster some dup packets are created with different Capture IDs. This code filters the dups only in the call flow. We've been using this for a while with no issues.