### PR TITLE
Support for http_settings.path to be injected via HTTP_PATH ENV

### DIFF
--- a/docker/docker-entrypoint.d/1
+++ b/docker/docker-entrypoint.d/1
@@ -36,6 +36,8 @@ if [ -f /usr/local/homer/etc/webapp_config.json ]; then
    if [ -n "$HTTP_HOST" ]; then sed -i "s/0.0.0.0/${HTTP_HOST}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$HTTP_PORT" ]; then sed -i "s/homer_web_port/${HTTP_PORT}/g" /usr/local/homer/etc/webapp_config.json; 
    else sed -i "s/homer_web_port/80/g" /usr/local/homer/etc/webapp_config.json; fi
+   if [ -n "$HTTP_PATH" ]; then sed -i "s=homer_serve_path=${HTTP_PATH}=g" /usr/local/homer/etc/webapp_config.json;
+   else sed -i "s=homer_serve_path=/=g" /usr/local/homer/etc/webapp_config.json; fi
 
    if [ -n "$AUTH_TYPE" ]; then sed -i "/type/ s/internal/${AUTH_TYPE}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$LDAP_BASE" ]; then sed -i "/base/ s/dc=example,dc=com/${LDAP_BASE}/g" /usr/local/homer/etc/webapp_config.json; fi

--- a/docker/webapp_config.json
+++ b/docker/webapp_config.json
@@ -39,6 +39,7 @@
     "host": "0.0.0.0",
     "port": homer_web_port,
     "root": "/usr/local/homer/dist",
+    "path": "homer_serve_path",
     "gzip": true,
     "debug": false
   },


### PR DESCRIPTION
Support for http_settings.path to be injected via HTTP_PATH environment variable. 
This will allow to serve the application in a relative path in the dockerized version of the application. 