### PR TITLE
:bug: received parameters must be decoded, not encoded.

### DIFF
--- a/controller/v1/advanced.go
+++ b/controller/v1/advanced.go
@@ -108,7 +108,10 @@ func (ac *AdvancedController) AddAdvanced(c echo.Context) error {
 //   201: body:GlobalSettingsUpdateSuccessfulResponse
 //   400: body:FailureResponse
 func (ac *AdvancedController) UpdateAdvancedAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ac.AdvancedService.GetAdvancedAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -159,7 +162,10 @@ func (ac *AdvancedController) UpdateAdvancedAgainstGUID(c echo.Context) error {
 //   201: body:GlobalSettingsDeleteSuccessfulResponse
 //   400: body:FailureResponse
 func (ac *AdvancedController) DeleteAdvancedAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ac.AdvancedService.GetAdvancedAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -199,7 +205,10 @@ func (ac *AdvancedController) DeleteAdvancedAgainstGUID(c echo.Context) error {
 //   400: body:FailureResponse
 func (ac *AdvancedController) GetAdvancedAgainstGUID(c echo.Context) error {
 
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ac.AdvancedService.GetAdvancedAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, webmessages.GetAdvancedAgainstFailed)

--- a/controller/v1/agentSub.go
+++ b/controller/v1/agentSub.go
@@ -125,7 +125,10 @@ func (ass *AgentsubController) GetAgentsubByType(c echo.Context) error {
 //	201: body:AgentsLocationList
 //	400: body:FailureResponse
 func (ass *AgentsubController) GetAgentsubAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ass.AgentsubService.GetAgentsubAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -240,12 +243,15 @@ func (ass *AgentsubController) AddAgentsubWithKey(c echo.Context) error {
 //	201: body:AgentLocationUpdateSuccessResponse
 //	400: body:FailureResponse
 func (ass *AgentsubController) UpdateAgentsubAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ass.AgentsubService.GetAgentsubAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
 	}
-	// Stub an user to be populated from the body
+	// Stub a user to be populated from the body
 	u := model.TableAgentLocationSession{}
 	err = c.Bind(&u)
 	if err != nil {
@@ -295,8 +301,10 @@ func (ass *AgentsubController) UpdateAgentsubAgainstGUID(c echo.Context) error {
 //	201: body:AgentLocationDeleteSuccessResponse
 //	400: body:FailureResponse
 func (ass *AgentsubController) DeleteAgentsubAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
-
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ass.AgentsubService.GetAgentsubAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -349,8 +357,14 @@ func (ass *AgentsubController) DeleteAgentsubAgainstGUID(c echo.Context) error {
 //	201: body:AgentsLocationList
 //	400: body:FailureResponse
 func (ass *AgentsubController) GetAgentSearchByTypeAndGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
-	typeRequest := url.QueryEscape(c.Param("type"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
+	typeRequest, err := url.QueryUnescape(c.Param("type"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 
 	transactionObject := model.SearchObject{}
 	if err := c.Bind(&transactionObject); err != nil {

--- a/controller/v1/agentSub.go
+++ b/controller/v1/agentSub.go
@@ -83,10 +83,13 @@ func (ass *AgentsubController) GetAgentsub(c echo.Context) error {
 //	200: body:AgentsLocationList
 //	400: body:FailureResponse
 func (ass *AgentsubController) GetAgentsubByType(c echo.Context) error {
-	typeRequest := url.QueryEscape(c.Param("type"))
+	typeRequest, err := url.QueryUnescape(c.Param("type"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ass.AgentsubService.GetAgentsubAgainstType(typeRequest)
 	if err != nil {
-		return httpresponse.CreateSuccessResponseWithJson(&c, http.StatusOK, []byte(reply))
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
 	}
 	return httpresponse.CreateSuccessResponseWithJson(&c, http.StatusOK, []byte(reply))
 }

--- a/controller/v1/authtoken.go
+++ b/controller/v1/authtoken.go
@@ -77,7 +77,10 @@ func (ass *AuthtokenController) GetAuthtoken(c echo.Context) error {
 //   200: body:AuthToken
 //   400: body:FailureResponse
 func (ass *AuthtokenController) GetAuthtokenAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ass.AuthtokenService.GetAuthtokenAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -178,12 +181,15 @@ func (ass *AuthtokenController) AddAuthtoken(c echo.Context) error {
 //   201: body:AuthTokenUpdateSuccessfulResponse
 //   400: body:FailureResponse
 func (ass *AuthtokenController) UpdateAuthtokenAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ass.AuthtokenService.GetAuthtokenAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
 	}
-	// Stub an user to be populated from the body
+	// Stub a user to be populated from the body
 	u := model.TableAuthToken{}
 	err = c.Bind(&u)
 	if err != nil {
@@ -230,8 +236,10 @@ func (ass *AuthtokenController) UpdateAuthtokenAgainstGUID(c echo.Context) error
 //   201: body:AuthTokenDeleteSuccessfulResponse
 //   400: body:FailureResponse
 func (ass *AuthtokenController) DeleteAuthtokenAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
-
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := ass.AuthtokenService.GetAuthtokenAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())

--- a/controller/v1/dashboard.go
+++ b/controller/v1/dashboard.go
@@ -184,7 +184,10 @@ func (dbc *DashBoardController) InsertDashboard(c echo.Context) error {
 
 	cc := c.(model.AppContext)
 	username := cc.UserName
-	dashboardId := url.QueryEscape(c.Param("dashboardId"))
+	dashboardId, err := url.QueryUnescape(c.Param("dashboardId"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 
 	logger.Debug("*** Database Session created *** ")
 
@@ -244,7 +247,10 @@ func (dbc *DashBoardController) UpdateDashboard(c echo.Context) error {
 
 	cc := c.(model.AppContext)
 	username := cc.UserName
-	dashboardId := url.QueryEscape(c.Param("dashboardId"))
+	dashboardId, err := url.QueryUnescape(c.Param("dashboardId"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 
 	var jsonData map[string]interface{} = map[string]interface{}{}
 	if err := c.Bind(&jsonData); err != nil {
@@ -296,7 +302,10 @@ func (dbc *DashBoardController) DeleteDashboard(c echo.Context) error {
 
 	cc := c.(model.AppContext)
 	username := cc.UserName
-	dashboardId := url.QueryEscape(c.Param("dashboardId"))
+	dashboardId, err := url.QueryUnescape(c.Param("dashboardId"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := dbc.DashBoardService.DeleteDashboard(username, dashboardId)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, webmessages.DeleteDashboardFailed)

--- a/controller/v1/hepsub.go
+++ b/controller/v1/hepsub.go
@@ -74,7 +74,10 @@ func (hsc *HepsubController) GetHepSub(c echo.Context) error {
 //   201: body:HepsubSchema
 //   400: body:FailureResponse
 func (hsc *HepsubController) GetHepSubAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := hsc.HepsubService.GetHepSubAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -116,8 +119,14 @@ func (hsc *HepsubController) GetHepSubAgainstGUID(c echo.Context) error {
 //   201: body:HepsubSchema
 //   400: body:FailureResponse
 func (hsc *HepsubController) GetHepSubFields(c echo.Context) error {
-	id := url.QueryEscape(c.Param("id"))
-	transaction := url.QueryEscape(c.Param("transaction"))
+	id, err := url.QueryUnescape(c.Param("id"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
+	transaction, err := url.QueryUnescape(c.Param("transaction"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := hsc.HepsubService.GetHepSubFields(id, transaction)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -205,7 +214,10 @@ func (hsc *HepsubController) AddHepSub(c echo.Context) error {
 //   201: body:HepsubUpdateSuccessResponse
 //   400: body:FailureResponse
 func (hsc *HepsubController) UpdateHepSubAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := hsc.HepsubService.GetHepSubAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -256,8 +268,10 @@ func (hsc *HepsubController) UpdateHepSubAgainstGUID(c echo.Context) error {
 //   201: body:HepsubDeleteSuccessResponse
 //   400: body:FailureResponse
 func (hsc *HepsubController) DeleteHepSubAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
-
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := hsc.HepsubService.GetHepSubAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())

--- a/controller/v1/mapping.go
+++ b/controller/v1/mapping.go
@@ -89,8 +89,14 @@ func (mpc *MappingController) GetMapping(c echo.Context) error {
 //	400: body:FailureResponse
 func (mpc *MappingController) GetMappingFields(c echo.Context) error {
 
-	id := url.QueryEscape(c.Param("id"))
-	transaction := url.QueryEscape(c.Param("transaction"))
+	id, err := url.QueryUnescape(c.Param("id"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
+	transaction, err := url.QueryUnescape(c.Param("transaction"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := mpc.MappingService.GetMappingFields(id, transaction)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, webmessages.MappingSchemaFailed)
@@ -131,7 +137,10 @@ func (mpc *MappingController) GetMappingFields(c echo.Context) error {
 //	400: body:FailureResponse
 func (mpc *MappingController) GetMappingAgainstGUID(c echo.Context) error {
 
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := mpc.MappingService.GetMappingAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, webmessages.MappingSchemaByUUIDFailed)
@@ -226,7 +235,10 @@ func (mpc *MappingController) AddMapping(c echo.Context) error {
 //	201: body:MappingUpdateSuccessResponse
 //	400: body:FailureResponse
 func (mpc *MappingController) UpdateMappingAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := mpc.MappingService.GetMappingAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -281,7 +293,10 @@ func (mpc *MappingController) UpdateMappingAgainstGUID(c echo.Context) error {
 //	201: body:MappingDeleteSuccessResponse
 //	400: body:FailureResponse
 func (mpc *MappingController) DeleteMappingAgainstGUID(c echo.Context) error {
-	guid := url.QueryEscape(c.Param("guid"))
+	guid, err := url.QueryUnescape(c.Param("guid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 	reply, err := mpc.MappingService.GetMappingAgainstGUID(guid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
@@ -331,8 +346,14 @@ func (mpc *MappingController) DeleteMappingAgainstGUID(c echo.Context) error {
 //	400: body:FailureResponse
 func (mpc *MappingController) GetSmartHepProfile(c echo.Context) error {
 
-	hepid := url.QueryEscape(c.Param("hepid"))
-	profile := url.QueryEscape(c.Param("profile"))
+	hepid, err := url.QueryUnescape(c.Param("hepid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
+	profile, err := url.QueryUnescape(c.Param("profile"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
 
 	queryString := c.QueryString()
 
@@ -434,8 +455,11 @@ func (mpc *MappingController) ResetMappingAgainstUUID(c echo.Context) error {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, webmessages.MappingRecreateFailed)
 	}
 
-	uuid := url.QueryEscape(c.Param("uuid"))
-	err := mpc.MappingService.RecreateMappingByUUID(uuid)
+	uuid, err := url.QueryUnescape(c.Param("uuid"))
+	if err != nil {
+		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, err.Error())
+	}
+	err = mpc.MappingService.RecreateMappingByUUID(uuid)
 	if err != nil {
 		return httpresponse.CreateBadResponse(&c, http.StatusBadRequest, webmessages.MappingSchemaByUUIDFailed)
 	}


### PR DESCRIPTION
When `GetAgentsubByType()` is called from the API its parameters are currently being encoded on receipt - this seems incorrect.

Note that there are other methods in agentsSub.go which perform the same action so at this point I am flagging as draft as these may need patching too if agreed by the maintainers.