### PR TITLE
add configurable service root to oauth config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ type HomerSettingServer struct {
 		ServiceProviderImage string   `default:""`
 		StateValue           string   `default:"jkwh027yasj"`
 		UrlToServiceRedirect string   `default:"/api/v3/oauth2/redirect"`
+                UrlToService         string   `default:"/"`
 		Scope                []string `default:"[email,openid,profile]"`
 		EnableGravatar       bool     `default:"false"`
 		EnableAutoRedirect   bool     `default:"false"`

--- a/controller/v1/user.go
+++ b/controller/v1/user.go
@@ -526,7 +526,7 @@ func (uc *UserController) AuthSericeRequest(c echo.Context) error {
 	config.OAuth2TokenMap[ssoToken] = oAuth2Object
 
 	//c.Response().Header().Add("Authorization", "Bearer "+token.AccessToken)
-	return c.Redirect(http.StatusFound, "/?token="+ssoToken)
+	return c.Redirect(http.StatusFound, config.Setting.OAUTH2_SETTINGS.UrlToService+"?token="+ssoToken)
 
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Jeffail/gabs v1.4.0
 	github.com/Jeffail/gabs/v2 v2.2.0
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f
 	github.com/fsnotify/fsnotify v1.4.9
@@ -19,7 +19,7 @@ require (
 	github.com/jinzhu/gorm v1.9.11
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/labstack/echo/v4 v4.5.0
-	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/labstack/gommon v0.3.0
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
 	github.com/lestrrat-go/strftime v1.0.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/spf13/viper v1.8.1
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
-	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1 // indirect
+	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0
 	gopkg.in/ldap.v3 v3.1.0

--- a/main.go
+++ b/main.go
@@ -423,6 +423,9 @@ func configureServiceObjects() {
 	if viper.IsSet("oauth2.service_redirect") {
 		config.Setting.OAUTH2_SETTINGS.UrlToServiceRedirect = viper.GetString("oauth2.service_redirect")
 	}
+	if viper.IsSet("oauth2.service_root") {
+		config.Setting.OAUTH2_SETTINGS.UrlToService = viper.GetString("oauth2.service_root")
+	}
 	if viper.IsSet("oauth2.scope") {
 		config.Setting.OAUTH2_SETTINGS.Scope = viper.GetStringSlice("oauth2.scope")
 	}


### PR DESCRIPTION
In the oauth2 configuration, add a new config item `service_root` which will be used as the path for the 302 redirection to the application upon authentication by the service provider.

This value will default to `/`, so existing behavior will be unchanged.

This will allow for oauth to be used in installations where the application is not served directly from the root path

Also, `mod.go` was modified when building so I checked it in.  This does not affect my change so I can revert that if you'd like