### PR TITLE
Make TLS version configurable

### DIFF
--- a/etc/webapp_config.json
+++ b/etc/webapp_config.json
@@ -89,6 +89,8 @@
     "enable": false,
     "host": "0.0.0.0",
     "port": 443,
+    "min_tls_version": "1.2",
+    "use_mozilla_profile": true,
     "cert": "/usr/local/homer/tls/cert.pem",
     "key": "/usr/local/homer/tls/key.pem"
   },


### PR DESCRIPTION
By default the echo server used in homer-app serves TLS 1.0.
Since both TLS 1.0 and TLS 1.1 are considered deprecated (see: https://datatracker.ietf.org/doc/rfc8996/) the minimum TLS version should therefore be configurable and set to TLS 1.2 as the default value.

Also support Mozilla profiles (restricts cipher suites based on TLS version)