### PR TITLE
Add Escaping for Identifiers and Literals in Migrations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
 	github.com/lestrrat-go/strftime v1.0.5 // indirect
+	github.com/lib/pq v1.1.1
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/satori/go.uuid v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
 	github.com/lestrrat-go/strftime v1.0.5 // indirect
-	github.com/lib/pq v1.1.1
+	github.com/lib/pq v1.10.9
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/lestrrat-go/strftime v1.0.5 h1:A7H3tT8DhTz8u65w+JRpiBxM4dINQhUXAZnhBa
 github.com/lestrrat-go/strftime v1.0.5/go.mod h1:E1nN3pCbtMSu1yjSVeyuRFVm/U0xoR76fd03sz+Qz4g=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -54,9 +54,12 @@ func CreateNewUser(dataRootDBSession *gorm.DB, user *string, password *string) {
 
 	heputils.Colorize(heputils.ColorRed, createString)
 
-	sql := fmt.Sprintf("CREATE USER %s WITH PASSWORD ?", pq.QuoteIdentifier(*user))
+	userQuoted := pq.QuoteIdentifier(*user)
+	passwordQuoted := pq.QuoteLiteral(*password)
 
-	dataRootDBSession.Debug().Exec(sql, *password)
+	sql := fmt.Sprintf("CREATE USER %s WITH PASSWORD %s", userQuoted, passwordQuoted)
+
+	dataRootDBSession.Debug().Exec(sql)
 
 	heputils.Colorize(heputils.ColorYellow, "\r\nDONE")
 
@@ -81,7 +84,7 @@ func CreateHomerDB(dataRootDBSession *gorm.DB, dbname *string, user *string) {
 
 	heputils.Colorize(heputils.ColorRed, createString)
 
-	sql := fmt.Sprintf("CREATE DATABASE %s OWNER %s", p.QuoteIdentifier(*dbname), pq.QuoteIdentifier(*user))
+	sql := fmt.Sprintf("CREATE DATABASE %s OWNER %s", pq.QuoteIdentifier(*dbname), pq.QuoteIdentifier(*user))
 
 	dataRootDBSession.Debug().Exec(sql)
 

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sipcapture/homer-app/migration/jsonschema"
@@ -53,9 +54,9 @@ func CreateNewUser(dataRootDBSession *gorm.DB, user *string, password *string) {
 
 	heputils.Colorize(heputils.ColorRed, createString)
 
-	sql := fmt.Sprintf("CREATE USER %s WITH PASSWORD  '%s'", *user, *password)
+	sql := fmt.Sprintf("CREATE USER %s WITH PASSWORD ?", pq.QuoteIdentifier(*user))
 
-	dataRootDBSession.Debug().Exec(sql)
+	dataRootDBSession.Debug().Exec(sql, *password)
 
 	heputils.Colorize(heputils.ColorYellow, "\r\nDONE")
 
@@ -67,7 +68,7 @@ func DeleteNewUser(dataRootDBSession *gorm.DB, user *string) {
 
 	heputils.Colorize(heputils.ColorRed, createString)
 
-	sql := fmt.Sprintf("DROP ROLE IF EXISTS %s", *user)
+	sql := fmt.Sprintf("DROP ROLE IF EXISTS %s", pq.QuoteIdentifier(*user))
 
 	dataRootDBSession.Debug().Exec(sql)
 
@@ -80,7 +81,7 @@ func CreateHomerDB(dataRootDBSession *gorm.DB, dbname *string, user *string) {
 
 	heputils.Colorize(heputils.ColorRed, createString)
 
-	sql := fmt.Sprintf("CREATE DATABASE %s OWNER %s", *dbname, *user)
+	sql := fmt.Sprintf("CREATE DATABASE %s OWNER %s", p.QuoteIdentifier(*dbname), pq.QuoteIdentifier(*user))
 
 	dataRootDBSession.Debug().Exec(sql)
 
@@ -93,20 +94,24 @@ func CreateHomerRole(dataRootDBSession *gorm.DB, dataHomeDBSession *gorm.DB, use
 
 	heputils.Colorize(heputils.ColorRed, createString)
 
-	sql := fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s to %s;", *homerDBconfig, *user)
+	userQuoted := pq.QuoteIdentifier(*user)
+	homeDBConfigQuoted := pq.QuoteIdentifier(*homerDBconfig)
+	homeDBDataQuoted := pq.QuoteIdentifier(*homerDBdata)
+
+	sql := fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s to %s;", homeDBConfigQuoted, userQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
-	sql = fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s to %s;", *homerDBdata, *user)
+	sql = fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s to %s;", homeDBDataQuoted, userQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
-	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO %s;", *homerDBconfig, *user)
+	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO %s;", homeDBConfigQuoted, userQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
-	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO %s;", *homerDBdata, *user)
+	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO %s;", homeDBDataQuoted, userQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
-	sql = "SELECT  schemaname, tablename, tableowner FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' " +
-		"AND schemaname != 'information_schema' AND tableowner != '" + *user + "' AND tablename LIKE 'hep_proto%'"
+	sql = "SELECT schemaname, tablename, tableowner FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' " +
+		"AND schemaname != 'information_schema' AND tableowner != " + pq.QuoteLiteral(*user) + " AND tablename LIKE 'hep_proto%'"
 
 	var Schemaname, Tablename, Tableowner string
 	rows, _ := dataHomeDBSession.Debug().Raw(sql).Rows() // (*sql.Rows, error)
@@ -116,7 +121,7 @@ func CreateHomerRole(dataRootDBSession *gorm.DB, dataHomeDBSession *gorm.DB, use
 		err := rows.Scan(&Schemaname, &Tablename, &Tableowner)
 		if err == nil {
 			fmt.Println(fmt.Sprintf("changing owner of [%s].[%s] from [%s] to [%s]", Schemaname, Tablename, Tableowner, *user))
-			sql = fmt.Sprintf("GRANT ALL ON TABLE %s.%s TO %s;", Schemaname, Tablename, *user)
+			sql = fmt.Sprintf("GRANT ALL ON TABLE %s.%s TO %s;", pq.QuoteIdentifier(Schemaname), pq.QuoteIdentifier(Tablename), userQuoted)
 			dataHomeDBSession.Debug().Exec(sql)
 		} else {
 			logger.Error(fmt.Sprintf("Some error during pg_catalog.pg_tables query: %s]: \n", err))
@@ -132,16 +137,20 @@ func RevokeHomerRole(dataRootDBSession *gorm.DB, user *string, homerDBconfig *st
 
 	heputils.Colorize(heputils.ColorRed, createString)
 
-	sql := fmt.Sprintf("REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s;", *homerDBconfig, *user)
+	userQuoted := pq.QuoteIdentifier(*user)
+	homeDBConfigQuoted := pq.QuoteIdentifier(*homerDBconfig)
+	homeDBDataQuoted := pq.QuoteIdentifier(*homerDBdata)
+
+	sql := fmt.Sprintf("REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s;", homeDBConfigQuoted, userQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
-	sql = fmt.Sprintf("REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s;", *homerDBdata, *user)
+	sql = fmt.Sprintf("REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s;", homeDBDataQuoted, userQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
-	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO postgres;", *homerDBconfig)
+	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO postgres;", homeDBConfigQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
-	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO postgres;", *homerDBdata)
+	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO postgres;", homeDBDataQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
 	heputils.Colorize(heputils.ColorYellow, "\r\nDONE")
@@ -743,7 +752,7 @@ func PopulateHomerConfigTables(configDBSession *gorm.DB, homerDBconfig string, f
 		heputils.Colorize(heputils.ColorRed, "reinstalling "+tableName)
 		//configDBSession.Exec("TRUNCATE TABLE versions")
 		for _, el := range tableVersions {
-			sql := fmt.Sprintf("DELETE FROM versions WHERE table_name = '%s'", el.NameTable)
+			sql := fmt.Sprintf("DELETE FROM versions WHERE table_name = %s", pq.QuoteIdentifier(el.NameTable))
 			db := configDBSession.Exec(sql)
 			if db != nil && db.Error != nil {
 				logger.Error(fmt.Sprintf("Exec delete failed for table [%s]: with error %s", tableName, db.Error))


### PR DESCRIPTION
Fixes #537 

Adds escaping for identifiers (table names, users, etc) using `pq.QuoteIdentifier`, and for literals using `pq.QuoteLiteral`. This allows usernames with characters like `-` and `@`, passwords with `'`, and resolves a SQL injection vulnerability.

Updates `github.com/lib/pq` to the latest version. It needed to be upgraded to at least [v1.2.0](https://github.com/lib/pq/releases/tag/v1.2.0), which added the `QuoteLiteral` function.

Verification done thus far:
- Ran homer image targeting a database with a regular username/password
- Ran homer targeting a GCP Cloud SQL database with IAM authentication (which has `-` and `@` in the username)
- Ran the initialization commands in the readme
- Loaded the image onto a dev environment with a real setup and poked around in it