### PR TITLE
fix for using 'homer_user' as ldap groupname

### DIFF
--- a/docker/docker-entrypoint.d/1
+++ b/docker/docker-entrypoint.d/1
@@ -13,7 +13,7 @@ GRAFANA_HOST=${GRAFANA_HOST:-localhost}
 if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 
    if [ -n "$DB_HOST" ]; then sed -i "s/homer_db_host/${DB_HOST}/g" /usr/local/homer/etc/webapp_config.json; fi
-   if [ -n "$DB_USER" ]; then sed -i "s/homer_user/${DB_USER}/g" /usr/local/homer/etc/webapp_config.json; fi
+   if [ -n "$DB_USER" ]; then sed -i "s/homer_db_user/${DB_USER}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$DB_PASS" ]; then sed -i "s/homer_password/${DB_PASS}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$DB_KEEPALIVE" ]; then sed -i "s/homer_db_keepalive/${DB_KEEPALIVE}/g" /usr/local/homer/etc/webapp_config.json; fi
    if [ -n "$DB_HOMER_CONFIG" ]; then sed -i "s/homer_config/${DB_HOMER_CONFIG}/g" /usr/local/homer/etc/webapp_config.json; fi

--- a/docker/webapp_config.json
+++ b/docker/webapp_config.json
@@ -2,14 +2,14 @@
   "database_data": {
     "local": {
       "node": "LocalNode",
-      "user": "homer_user",
+      "user": "homer_db_user",
       "pass": "homer_password",
       "name": "homer_data",
       "host": "homer_db_host"
     }
   },
   "database_config": {
-    "user": "homer_user",
+    "user": "homer_db_user",
     "pass": "homer_password",
     "name": "homer_config",
     "host": "homer_db_host",


### PR DESCRIPTION
There are 2 issues where "homer_user" as a LDAP usergroup name clashes with db user in entrypoint.sh as mentioned here: [](https://github.com/sipcapture/homer/issues/592#issuecomment-2253164973)

 https://github.com/sipcapture/homer7-docker/issues/145
 https://github.com/sipcapture/homer/issues/592
 
 This PR will fix the issue.