### PR TITLE
Enables optional handling of PKCE

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ type HomerSettingServer struct {
 		Method               string   `default:"GET"`
 		ResponseType         string   `default:"code"`
 		GrantType            string   `default:"authorization_code"`
+		UsePkce              bool     `default:"true"`
 		UserToken            string   `default:"randommin43characterstringisneededasusertoken"`
 		ServiceProviderName  string   `default:"google"`
 		ServiceProviderImage string   `default:""`

--- a/controller/v1/user.go
+++ b/controller/v1/user.go
@@ -421,16 +421,17 @@ func (uc *UserController) RedirecToSericeAuth(c echo.Context) error {
 
 	logger.Debug("Doing URL for provider:", providerName)
 
-	u := ""
-	if config.Setting.OAUTH2_SETTINGS.UsePkce == true {
-		u = config.Setting.MAIN_SETTINGS.OAuth2Config.AuthCodeURL(config.Setting.OAUTH2_SETTINGS.StateValue,
-			oauth2.SetAuthURLParam("response_type", config.Setting.OAUTH2_SETTINGS.ResponseType),
+	options := []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("response_type", config.Setting.OAUTH2_SETTINGS.ResponseType),
+	}
+
+	if config.Setting.OAUTH2_SETTINGS.UsePkce {
+		options = append(options,
 			oauth2.SetAuthURLParam("code_challenge", heputils.GenCodeChallengeS256(config.Setting.OAUTH2_SETTINGS.UserToken)),
 			oauth2.SetAuthURLParam("code_challenge_method", "S256"))
-	} else {
-		u = config.Setting.MAIN_SETTINGS.OAuth2Config.AuthCodeURL(config.Setting.OAUTH2_SETTINGS.StateValue,
-			oauth2.SetAuthURLParam("response_type", config.Setting.OAUTH2_SETTINGS.ResponseType))
 	}
+
+	u := config.Setting.MAIN_SETTINGS.OAuth2Config.AuthCodeURL(config.Setting.OAUTH2_SETTINGS.StateValue, options...)
 
 	logger.Debug("RedirecToSericeAuth Redirecting URL :", u)
 

--- a/etc/webapp_config.json
+++ b/etc/webapp_config.json
@@ -176,6 +176,7 @@
         "grant_type": "authorization_code",
         "response_type": "code",
         "auth_style": 1,
+        "use_pkce": true,
         "user_token": "RandomURLSafeStringWithAMinimumLengthOf43Characters",
         "scope": [
             "email",

--- a/main.go
+++ b/main.go
@@ -391,6 +391,9 @@ func configureServiceObjects() {
 	if viper.IsSet("oauth2.response_type") {
 		config.Setting.OAUTH2_SETTINGS.ResponseType = viper.GetString("oauth2.response_type")
 	}
+	if viper.IsSet("oauth2.use_pkce") {
+		config.Setting.OAUTH2_SETTINGS.UsePkce = viper.GetBool("oauth2.use_pkce")
+	}
 	if viper.IsSet("oauth2.user_token") {
 		config.Setting.OAUTH2_SETTINGS.UserToken = viper.GetString("oauth2.user_token")
 	}


### PR DESCRIPTION
Some OAuth provider do not have support for PKCE. This PR uses a feature flag to use/not use PKCE-specific fields during OAuth process.

Default is the current behaviour where PKCE is enabled