### PR TITLE
Fix code scanning alert no. 14: Potentially unsafe quoting

### DIFF
--- a/data/service/hepsub.go
+++ b/data/service/hepsub.go
@@ -60,8 +60,12 @@ func (hs *HepsubService) GetHepSubFields(id, transaction string) (string, error)
 		return "", err
 	}
 	data, _ := json.Marshal(hepsubObject)
-	response := fmt.Sprintf("{\"count\":%d,\"data\":\"%s\"}", count, string(data))
-	return response, nil
+	responseMap := map[string]interface{}{
+		"count": count,
+		"data":  json.RawMessage(data),
+	}
+	response, _ := json.Marshal(responseMap)
+	return string(response), nil
 }
 
 // this method gets all users from database


### PR DESCRIPTION
Fixes [https://github.com/sipcapture/homer-app/security/code-scanning/14](https://github.com/sipcapture/homer-app/security/code-scanning/14)

To fix the problem, we need to ensure that the JSON string produced by `json.Marshal` is properly escaped before embedding it into another JSON string. The best way to fix this is to avoid manually constructing the JSON string and instead use a structured approach to build the JSON response.

We can use a map to construct the JSON response and then marshal the entire map to a JSON string. This approach ensures that all necessary escaping is handled by the `json.Marshal` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
