### PR TITLE
Fix code scanning alert no. 26: Disabled TLS certificate check

### DIFF
--- a/utils/ldap/ldap.go
+++ b/utils/ldap/ldap.go
@@ -100,7 +100,7 @@ func (lc *LDAPClient) Connect() error {
 	
 				// Reconnect with TLS
 				if !lc.SkipTLS {
-					err = l.StartTLS(&tls.Config{InsecureSkipVerify: true})
+					err = l.StartTLS(&tls.Config{InsecureSkipVerify: lc.InsecureSkipVerify})
 					if err != nil {
 						l.Close() // Close the connection before trying the next host
 						continue // Try the next host


### PR DESCRIPTION
Fixes [https://github.com/sipcapture/homer-app/security/code-scanning/26](https://github.com/sipcapture/homer-app/security/code-scanning/26)

To fix the problem, we need to ensure that TLS certificate verification is not disabled in production code. Instead of setting `InsecureSkipVerify` to `true`, we should configure the certificates properly so that verification can be performed. This involves removing the hardcoded `InsecureSkipVerify: true` and using the `lc.InsecureSkipVerify` flag, which should be set to `false` in production environments.

1. Remove the hardcoded `InsecureSkipVerify: true` from the `StartTLS` call.
2. Use the `lc.InsecureSkipVerify` flag to control the `InsecureSkipVerify` setting.
3. Ensure that the `lc.InsecureSkipVerify` flag is set to `false` in production environments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
