### PR TITLE
Fix code scanning alert no. 25: Clear-text logging of sensitive information

### DIFF
--- a/main.go
+++ b/main.go
@@ -2080,7 +2080,9 @@ func ShowCurrentConfigToConsole() {
 
 	heputils.Colorize(heputils.ColorRed, "\r\nLDAP:\r\n")
 
-	spew.Dump(ldapClient)
+	sanitizedLdapClient := ldapClient
+	sanitizedLdapClient.BindPassword = "REDACTED"
+	spew.Dump(sanitizedLdapClient)
 
 }
 


### PR DESCRIPTION
Fixes [https://github.com/sipcapture/homer-app/security/code-scanning/25](https://github.com/sipcapture/homer-app/security/code-scanning/25)

To fix the problem, we need to ensure that sensitive information such as `BindPassword` is not logged in clear text. The best way to fix this without changing existing functionality is to sanitize the `ldapClient` object before logging it. We can create a copy of the `ldapClient` object with the `BindPassword` field set to a placeholder value (e.g., "REDACTED") before logging it.

We will make the following changes:
1. Create a sanitized copy of the `ldapClient` object with the `BindPassword` field redacted.
2. Log the sanitized copy instead of the original `ldapClient` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
