### PR TITLE
Fix code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/data/service/agentSub.go
+++ b/data/service/agentSub.go
@@ -75,10 +75,8 @@ func (hs *AgentsubService) GetAgentsubAgainstType(typeRequest string) (string, e
 	var AgentsubObject []model.TableAgentLocationSession
 	var count int
 
-	whereSQL := fmt.Sprintf("expire_date > NOW() AND type LIKE '%%%s%%'", typeRequest)
-
 	if err := hs.Session.Debug().Table("agent_location_session").
-		Where(whereSQL).
+		Where("expire_date > NOW() AND type LIKE ?", "%"+typeRequest+"%").
 		Find(&AgentsubObject).Count(&count).Error; err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes [https://github.com/sipcapture/homer-app/security/code-scanning/1](https://github.com/sipcapture/homer-app/security/code-scanning/1)

To fix the problem, we need to use parameterized queries instead of string concatenation to construct the SQL query. This will ensure that user input is properly escaped and cannot be used to inject malicious SQL code.

- Replace the `fmt.Sprintf` function with a parameterized query using placeholders.
- Pass the `typeRequest` parameter as an argument to the `Where` method to safely embed it into the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
