### PR TITLE
Fix code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/data/service/agentSub.go
+++ b/data/service/agentSub.go
@@ -104,10 +104,8 @@ func (hs *AgentsubService) GetAgentsubAgainstGUIDAndType(guid string, typeReques
 	var AgentsubObject model.TableAgentLocationSession
 	var count int
 
-	whereSQL := fmt.Sprintf("expire_date > NOW() AND guid = '%s' AND type LIKE '%%%s%%'", guid, typeRequest)
-
 	if err := hs.Session.Debug().Table("agent_location_session").
-		Where(whereSQL).
+		Where("expire_date > NOW() AND guid = ? AND type LIKE ?", guid, "%"+typeRequest+"%").
 		Find(&AgentsubObject).Count(&count).Error; err != nil {
 		return AgentsubObject, err
 	}


### PR DESCRIPTION
Fixes [https://github.com/sipcapture/homer-app/security/code-scanning/2](https://github.com/sipcapture/homer-app/security/code-scanning/2)

To fix the problem, we should use parameterized queries instead of string concatenation to construct the SQL query. This approach ensures that user-provided values are properly escaped and cannot be used to inject malicious SQL code.

In the `GetAgentsubAgainstGUIDAndType` function, we will replace the `fmt.Sprintf` method with a parameterized query using placeholders (`?`) for the user-provided values (`guid` and `typeRequest`). We will then pass these values as arguments to the `Where` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
