### PR TITLE
Fix code scanning alert no. 11: Database query built from user-controlled sources

### DIFF
--- a/data/service/userSettings.go
+++ b/data/service/userSettings.go
@@ -208,19 +208,22 @@ func (ss *UserSettingsService) Delete(userObject *model.TableUserSettings, UserN
 // it doesn't check internally whether all the validation are applied or not
 func (ss *UserSettingsService) Update(userObject *model.TableUserSettings, UserName string, isAdmin bool) error {
 
-	var sqlWhere = make(map[string]interface{})
+	var sqlWhere string
+	var args []interface{}
 
 	if !isAdmin {
-		sqlWhere = map[string]interface{}{"guid": userObject.GUID, "username": UserName}
+		sqlWhere = "guid = ? AND username = ?"
+		args = append(args, userObject.GUID, UserName)
 	} else {
-		sqlWhere = map[string]interface{}{"guid": userObject.GUID}
+		sqlWhere = "guid = ?"
+		args = append(args, userObject.GUID)
 	}
 
 	if err := ss.Session.Debug().
 		Table("user_settings").
 		Debug().
 		Model(&model.TableUserSettings{}).
-		Where(sqlWhere).Update(userObject).Error; err != nil {
+		Where(sqlWhere, args...).Update(userObject).Error; err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Fixes [https://github.com/sipcapture/homer-app/security/code-scanning/11](https://github.com/sipcapture/homer-app/security/code-scanning/11)

To fix the problem, we should ensure that user-provided data is safely embedded into the SQL query using parameterized queries or prepared statements. In this case, we can rely on GORM's parameterized query capabilities to handle the user input safely.

- Modify the `Update` method in `data/service/userSettings.go` to use GORM's parameterized queries.
- Ensure that the `sqlWhere` map is constructed in a way that GORM can safely handle the parameters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
