### PR TITLE
Fix code scanning alert no. 10: Database query built from user-controlled sources

### DIFF
--- a/data/service/userSettings.go
+++ b/data/service/userSettings.go
@@ -177,7 +177,7 @@ func (ss *UserSettingsService) Get(userObject *model.TableUserSettings, UserName
 
 	if err := ss.Session.Debug().
 		Table("user_settings").
-		Where(sqlWhere).Find(&data).Error; err != nil {
+		Where("guid = ? AND username = ?", userObject.GUID, UserName).Find(&data).Error; err != nil {
 		return data, err
 	}
 	return data, nil
@@ -197,7 +197,7 @@ func (ss *UserSettingsService) Delete(userObject *model.TableUserSettings, UserN
 
 	if err := ss.Session.Debug().
 		Table("user_settings").
-		Where(sqlWhere).
+		Where("guid = ? AND username = ?", userObject.GUID, UserName).
 		Delete(model.TableUserSettings{}).Error; err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (ss *UserSettingsService) Update(userObject *model.TableUserSettings, UserN
 		Table("user_settings").
 		Debug().
 		Model(&model.TableUserSettings{}).
-		Where(sqlWhere).Update(userObject).Error; err != nil {
+		Where("guid = ? AND username = ?", userObject.GUID, UserName).Update(userObject).Error; err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Fixes [https://github.com/sipcapture/homer-app/security/code-scanning/10](https://github.com/sipcapture/homer-app/security/code-scanning/10)

To fix the problem, we should ensure that user-provided data is safely embedded into the SQL query using parameterized queries or prepared statements. This can be achieved by modifying the `Where` clause to use placeholders and passing the user-provided values as parameters. This approach prevents SQL injection by ensuring that the user input is treated as data rather than executable code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
