### PR TITLE
fix path for swagger

### DIFF
--- a/main.go
+++ b/main.go
@@ -755,6 +755,7 @@ func configureAsHTTPServer() {
 	}))
 
 	if config.Setting.SWAGGER.Enable {
+		prefix := config.Setting.MAIN_SETTINGS.APIPrefix
 		//e.GET("/swagger/*", echoSwagger.WrapHandler)
 		e.GET(prefix+"/doc/api/json", func(c echo.Context) error {
 

--- a/main.go
+++ b/main.go
@@ -756,7 +756,7 @@ func configureAsHTTPServer() {
 
 	if config.Setting.SWAGGER.Enable {
 		//e.GET("/swagger/*", echoSwagger.WrapHandler)
-		e.GET("/doc/api/json", func(c echo.Context) error {
+		e.GET(prefix+"/doc/api/json", func(c echo.Context) error {
 
 			logger.Debug("Middle swagger ware: ", c.Request().RequestURI)
 			dataJson, err := os.ReadFile(config.Setting.SWAGGER.ApiJson)


### PR DESCRIPTION
if webapp is located behind the an ALB with specific route path - this URL doesn't work