### PR TITLE
allow setting DB_ROOT_USER and DB_ROOT_PASS env variables for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:16-alpine as webapp
-ENV BUILD 20220211-001
+FROM node:16-alpine AS webapp
+ENV BUILD=20220211-001
 RUN apk add git && git clone https://github.com/sipcapture/homer-ui /app
 WORKDIR /app
 RUN npm install && npm install -g @angular/cli && npm run build
 
-FROM golang:alpine as webapi
-ENV BUILD 20220211-001
+FROM golang:alpine AS webapi
+ENV BUILD=20220211-001
 RUN apk --update add git make
 COPY . /homer-app
 WORKDIR /homer-app

--- a/docker/docker-entrypoint.d/9
+++ b/docker/docker-entrypoint.d/9
@@ -4,19 +4,21 @@ DB_HOST=${DB_HOST:-db}
 DB_PORT=${DB_PORT:-5432}
 DB_USER=${DB_USER:-root}
 DB_PASS=${DB_PASS:-homerSeven}
+DB_ROOT_USER=${DB_ROOT_USER:-$DB_USER}
+DB_ROOT_PASS=${DB_ROOT_PASS:-$DB_PASS}
 
 if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 
 ###Create user
-#/homer-app -create-homer-user -database-root-user=$DB_USER -database-host=$DB_HOST -database-root-password=$DB_PASS
+#/homer-app -create-homer-user -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-root-password=$DB_ROOT_PASS
 ###Show user
-#/homer-app -show-db-user -database-root-user=$DB_USER -database-host=$DB_HOST -database-root-password=$DB_PASS
+#/homer-app -show-db-user -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-root-password=$DB_ROOT_PASS
 ###Create Role
-#/homer-app -create-homer-role -database-root-user=$DB_USER -database-host=localhost -database-root-password=postgres -database-homer-data=homer_data -database-homer-config=homer_config
+#/homer-app -create-homer-role -database-root-user=$DB_ROOT_USER -database-host=localhost -database-root-password=$DB_ROOT_PASS -database-homer-data=homer_data -database-homer-config=homer_config
 
 ###Create DB
-/homer-app -create-config-db -database-root-user=$DB_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_PASS -database-homer-user=$DB_USER
-/homer-app -create-data-db -database-root-user=$DB_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_PASS -database-homer-user=$DB_USER
+/homer-app -create-config-db -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER
+/homer-app -create-data-db -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER
 
 #Save it or edit the webapp_config.json manualy
 #/homer-app -save-homer-db-config-settings -database-host=localhost -database-homer-config=homer_config -database-homer-user=homer_user -database-homer-password=homer_password


### PR DESCRIPTION
allow setting DB_ROOT_USER and DB_ROOT_PASS env variables for docker entrypoint. They default to the previous DB_USER and DB_PASS variables.

In our setup we are running homer with its own postgres account.  It fails to start because it tries to connect to the "postgres" database with the "homer_user" account, which isn't permitted. This change makes sure it can do the necessary operations in the `9` script of the docker-entrypoint.d directory.

Also fix a few docker warnings in the Dockerfile while we're at it.