### PR TITLE
Add pg_read_all_settings grant for homer role so database can be rotated

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -106,6 +106,10 @@ func CreateHomerRole(dataRootDBSession *gorm.DB, dataHomeDBSession *gorm.DB, use
 	sql = fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s to %s;", homeDBDataQuoted, userQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 
+	// To permit examining data_directory for rotation
+	sql = fmt.Sprintf("GRANT pg_read_all_settings TO %s;", userQuoted)
+	dataRootDBSession.Debug().Exec(sql)
+
 	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO %s;", homeDBConfigQuoted, userQuoted)
 	dataRootDBSession.Debug().Exec(sql)
 


### PR DESCRIPTION
In heplify-server we're getting errors that the database can't be rotated:
```
2025/10/21 04:45:00.074939 rotator.go:613: WARN pq: permission denied to examine "data_directory"
2025/10/21 04:45:00.074976 rotator.go:229: ERR Error getdb pq: permission denied to examine "data_directory"
2025/10/21 04:45:00.074986 rotator.go:266: ERR pq: permission denied to examine "data_directory"
2025/10/21 04:45:00.075076 rotator.go:513: ERR pq: permission denied to examine "data_directory"
```

We're using a dedicated role on the postgresql server. The role is created with the webapp so I'm adding the required grant for this here.