### PR TITLE
support postgres ssl mode in docker entrypoint

### DIFF
--- a/docker/docker-entrypoint.d/9
+++ b/docker/docker-entrypoint.d/9
@@ -6,29 +6,30 @@ DB_USER=${DB_USER:-root}
 DB_PASS=${DB_PASS:-homerSeven}
 DB_ROOT_USER=${DB_ROOT_USER:-$DB_USER}
 DB_ROOT_PASS=${DB_ROOT_PASS:-$DB_PASS}
+DB_SSL_MODE=${DB_SSL_MODE:-disable}
 
 if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 
 ###Create user
-#/homer-app -create-homer-user -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-root-password=$DB_ROOT_PASS
+#/homer-app -create-homer-user -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-root-password=$DB_ROOT_PASS -database-ssl-mode=$DB_SSL_MODE
 ###Show user
-#/homer-app -show-db-user -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-root-password=$DB_ROOT_PASS
+#/homer-app -show-db-user -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-root-password=$DB_ROOT_PASS -database-ssl-mode=$DB_SSL_MODE
 ###Create Role
-#/homer-app -create-homer-role -database-root-user=$DB_ROOT_USER -database-host=localhost -database-root-password=$DB_ROOT_PASS -database-homer-data=homer_data -database-homer-config=homer_config
+#/homer-app -create-homer-role -database-root-user=$DB_ROOT_USER -database-host=localhost -database-root-password=$DB_ROOT_PASS -database-homer-data=homer_data -database-homer-config=homer_config -database-ssl-mode=$DB_SSL_MODE
 
 ###Create DB
-/homer-app -create-config-db -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER
-/homer-app -create-data-db -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER
+/homer-app -create-config-db -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER -database-ssl-mode=$DB_SSL_MODE
+/homer-app -create-data-db -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER -database-ssl-mode=$DB_SSL_MODE
 
 #Save it or edit the webapp_config.json manualy
-#/homer-app -save-homer-db-config-settings -database-host=localhost -database-homer-config=homer_config -database-homer-user=homer_user -database-homer-password=homer_password
-#/homer-app -save-homer-db-data-settings -database-host=localhost -database-homer-data=homer_data -database-homer-user=homer_user -database-homer-password=homer_password
+#/homer-app -save-homer-db-config-settings -database-host=localhost -database-homer-config=homer_config -database-homer-user=homer_user -database-homer-password=homer_password -database-ssl-mode=$DB_SSL_MODE
+#/homer-app -save-homer-db-data-settings -database-host=localhost -database-homer-data=homer_data -database-homer-user=homer_user -database-homer-password=homer_password -database-ssl-mode=$DB_SSL_MODE
 
 #Create Table / Migration - connection data will be read from the webapp_config.json
-/homer-app -create-table-db-config -webapp-config-path=/usr/local/homer/etc
+/homer-app -create-table-db-config -webapp-config-path=/usr/local/homer/etc -database-ssl-mode=$DB_SSL_MODE
 
 #Populate DB
-/homer-app -populate-table-db-config -webapp-config-path=/usr/local/homer/etc
+/homer-app -populate-table-db-config -webapp-config-path=/usr/local/homer/etc -database-ssl-mode=$DB_SSL_MODE
 
    echo "Database provisioning completed!"
 


### PR DESCRIPTION
This adds postgres ssl mode support in the docker entrypoint. The default remains `disable`.