### PR TITLE
Allow configurable default admin and support user passwords. Also allow a different hostname for provisioning

### DIFF
--- a/docker/docker-entrypoint.d/9
+++ b/docker/docker-entrypoint.d/9
@@ -7,6 +7,7 @@ DB_PASS=${DB_PASS:-homerSeven}
 DB_ROOT_USER=${DB_ROOT_USER:-$DB_USER}
 DB_ROOT_PASS=${DB_ROOT_PASS:-$DB_PASS}
 DB_SSL_MODE=${DB_SSL_MODE:-disable}
+PROVISIONED_USERS_PASS=${PROVISIONED_USERS_PASS:-sipcapture}
 
 if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 
@@ -29,7 +30,7 @@ if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 /homer-app -create-table-db-config -webapp-config-path=/usr/local/homer/etc -database-ssl-mode=$DB_SSL_MODE
 
 #Populate DB
-/homer-app -populate-table-db-config -webapp-config-path=/usr/local/homer/etc -database-ssl-mode=$DB_SSL_MODE
+/homer-app -populate-table-db-config -webapp-config-path=/usr/local/homer/etc -database-ssl-mode=$DB_SSL_MODE -force-password=$PROVISIONED_USERS_PASS
 
    echo "Database provisioning completed!"
 

--- a/docker/docker-entrypoint.d/9
+++ b/docker/docker-entrypoint.d/9
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DB_HOST=${DB_HOST:-db}
+DB_PROVISIONING_HOST=${DB_PROVISIONING_HOST:-$DB_HOST}
 DB_PORT=${DB_PORT:-5432}
 DB_USER=${DB_USER:-root}
 DB_PASS=${DB_PASS:-homerSeven}
@@ -12,15 +13,15 @@ PROVISIONED_USERS_PASS=${PROVISIONED_USERS_PASS:-sipcapture}
 if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 
 ###Create user
-#/homer-app -create-homer-user -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-root-password=$DB_ROOT_PASS -database-ssl-mode=$DB_SSL_MODE
+#/homer-app -create-homer-user -database-root-user=$DB_ROOT_USER -database-host=$DB_PROVISIONING_HOST -database-root-password=$DB_ROOT_PASS -database-ssl-mode=$DB_SSL_MODE
 ###Show user
-#/homer-app -show-db-user -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-root-password=$DB_ROOT_PASS -database-ssl-mode=$DB_SSL_MODE
+#/homer-app -show-db-user -database-root-user=$DB_ROOT_USER -database-host=$DB_PROVISIONING_HOST -database-root-password=$DB_ROOT_PASS -database-ssl-mode=$DB_SSL_MODE
 ###Create Role
 #/homer-app -create-homer-role -database-root-user=$DB_ROOT_USER -database-host=localhost -database-root-password=$DB_ROOT_PASS -database-homer-data=homer_data -database-homer-config=homer_config -database-ssl-mode=$DB_SSL_MODE
 
 ###Create DB
-/homer-app -create-config-db -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER -database-ssl-mode=$DB_SSL_MODE
-/homer-app -create-data-db -database-root-user=$DB_ROOT_USER -database-host=$DB_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER -database-ssl-mode=$DB_SSL_MODE
+/homer-app -create-config-db -database-root-user=$DB_ROOT_USER -database-host=$DB_PROVISIONING_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER -database-ssl-mode=$DB_SSL_MODE
+/homer-app -create-data-db -database-root-user=$DB_ROOT_USER -database-host=$DB_PROVISIONING_HOST -database-port=$DB_PORT -database-root-password=$DB_ROOT_PASS -database-homer-user=$DB_USER -database-ssl-mode=$DB_SSL_MODE
 
 #Save it or edit the webapp_config.json manualy
 #/homer-app -save-homer-db-config-settings -database-host=localhost -database-homer-config=homer_config -database-homer-user=homer_user -database-homer-password=homer_password -database-ssl-mode=$DB_SSL_MODE

--- a/docker/docker-entrypoint.d/9
+++ b/docker/docker-entrypoint.d/9
@@ -8,7 +8,7 @@ DB_PASS=${DB_PASS:-homerSeven}
 DB_ROOT_USER=${DB_ROOT_USER:-$DB_USER}
 DB_ROOT_PASS=${DB_ROOT_PASS:-$DB_PASS}
 DB_SSL_MODE=${DB_SSL_MODE:-disable}
-PROVISIONED_USERS_PASS=${PROVISIONED_USERS_PASS:-$(cat /dev/urandom | tr -dc 'A-Za-z0-9' | head -c 32)}
+PROVISIONED_USERS_PASS=${PROVISIONED_USERS_PASS:-}
 
 if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 

--- a/docker/docker-entrypoint.d/9
+++ b/docker/docker-entrypoint.d/9
@@ -8,7 +8,7 @@ DB_PASS=${DB_PASS:-homerSeven}
 DB_ROOT_USER=${DB_ROOT_USER:-$DB_USER}
 DB_ROOT_PASS=${DB_ROOT_PASS:-$DB_PASS}
 DB_SSL_MODE=${DB_SSL_MODE:-disable}
-PROVISIONED_USERS_PASS=${PROVISIONED_USERS_PASS:-sipcapture}
+PROVISIONED_USERS_PASS=${PROVISIONED_USERS_PASS:-$(cat /dev/urandom | tr -dc 'A-Za-z0-9' | head -c 32)}
 
 if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 

--- a/docker/docker-entrypoint.d/9
+++ b/docker/docker-entrypoint.d/9
@@ -31,7 +31,7 @@ if [ -f /usr/local/homer/etc/webapp_config.json ]; then
 /homer-app -create-table-db-config -webapp-config-path=/usr/local/homer/etc -database-ssl-mode=$DB_SSL_MODE
 
 #Populate DB
-/homer-app -populate-table-db-config -webapp-config-path=/usr/local/homer/etc -database-ssl-mode=$DB_SSL_MODE -force-password=$PROVISIONED_USERS_PASS
+/homer-app -populate-table-db-config -webapp-config-path=/usr/local/homer/etc -database-ssl-mode=$DB_SSL_MODE "-force-password=$PROVISIONED_USERS_PASS"
 
    echo "Database provisioning completed!"
 

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -83,7 +83,17 @@ func CreateHomerDB(dataRootDBSession *gorm.DB, dbname *string, user *string) {
 
 	heputils.Colorize(heputils.ColorRed, createString)
 
-	sql := fmt.Sprintf("CREATE DATABASE %s OWNER %s", pq.QuoteIdentifier(*dbname), pq.QuoteIdentifier(*user))
+	/*
+	 * Create database first, and only then change the owner, because of possible error "permission
+	 * denied to create database" for non-superusers. Relevant on AWS RDS setups where the "root" account
+	 * is not a superuser role.
+	 */
+
+	sql := fmt.Sprintf("CREATE DATABASE %s", pq.QuoteIdentifier(*dbname))
+
+	dataRootDBSession.Debug().Exec(sql)
+
+	sql = fmt.Sprintf("ALTER DATABASE %s OWNER TO %s", pq.QuoteIdentifier(*dbname), pq.QuoteIdentifier(*user))
 
 	dataRootDBSession.Debug().Exec(sql)
 


### PR DESCRIPTION
This adds support for having another default provisioned user password for the admin and support users.

It also adds support to have a different hostname for postgres database provisioning. This is useful when a pgbouncer is in front of the postgres database which does not allow connecting as a superuser role by default. You can then bypass the pgbouncer by connecting to the database directly.