### PR TITLE
Fix typo in DB_PORT environment variable parsing in entrypoint script 1

### DIFF
--- a/docker/docker-entrypoint.d/1
+++ b/docker/docker-entrypoint.d/1
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DB_HOST=${DB_HOST:-localhost}
-DB_PORT=${DB_HOST:-5432}
+DB_PORT=${DB_PORT:-5432}
 DB_KEEPALIVE=${DB_KEEPALIVE:-false} #default to false
 DB_KEEPALIVE=${DB_KEEPALIVE,,} #set to lower-case
 DB_HOMER_CONFIG=${DB_HOMER_CONFIG:-homer_config}


### PR DESCRIPTION
The DB_PORT variable was incorrectly reading from DB_HOST. This bug was introduced in PR #572.