### PR TITLE
fix: format call id as bigint in IN clause to avoid scientific notation

### DIFF
--- a/data/service/search.go
+++ b/data/service/search.go
@@ -608,7 +608,7 @@ func (ss *SearchService) GetDecodedMessageByID(searchObject *model.SearchObject)
 				elems := sData.Search(key, "uuid").Data().([]interface{})
 				keyData := []string{}
 				for _, val := range elems {
-					keyData = append(keyData, fmt.Sprintf("%v", val))
+					keyData = append(keyData, fmt.Sprintf("%d", int64(val.(float64))))
 				}
 				sql = sql + " AND " + fmt.Sprintf("%s IN (%s)", "id", strings.Join(keyData[:], ","))
 			}
@@ -716,7 +716,7 @@ func (ss *SearchService) GetMessageByID(searchObject *model.SearchObject) (strin
 				elems := sData.Search(key, "uuid").Data().([]interface{})
 				keyData := []string{}
 				for _, val := range elems {
-					keyData = append(keyData, fmt.Sprintf("%v", val))
+					keyData = append(keyData, fmt.Sprintf("%d", int64(val.(float64))))
 				}
 				sql = sql + " AND " + fmt.Sprintf("%s IN (%s)", "id", strings.Join(keyData[:], ","))
 			}


### PR DESCRIPTION
## Summary

`GetMessageByID` and `GetDecodedMessageByID` build the `id IN (...)` clause by formatting each value with `fmt.Sprintf("%v", val)`. Because `gabs` parses JSON numbers as `float64`, values larger than ~1e6 render in scientific notation (e.g. `3.2218272741e+10`). PostgreSQL then treats the literal as `numeric`, applies an implicit `(id)::numeric` cast on every row, disables the `bigint` btree index on `id`, and falls back to a parallel sequential scan across **every call partition**.

On setups with hundreds of hourly partitions this turns a single call-by-id lookup into a 30+ minute query that holds `DataFileRead` / `BufferIO` waits and blocks other users.

## Fix

Cast the value to `int64` and format with `%d` so the SQL literal is a plain bigint:

```diff
- keyData = append(keyData, fmt.Sprintf("%v", val))
+ keyData = append(keyData, fmt.Sprintf("%d", int64(val.(float64))))
```

Applied in both `data/service/search.go` call sites (`GetDecodedMessageByID` and `GetMessageByID`).

### Before

```
WHERE (create_date between $1 and $2 AND id IN (3.2218272741e+10)) LIMIT 200
-> Parallel Seq Scan ... Filter: ((id)::numeric = '32218272741'::numeric)
```

### After

```
WHERE (create_date between $1 and $2 AND id IN (32218272741)) LIMIT 200
-> Index Scan using <pk> ... Index Cond: (id = 32218272741)
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test -vet=off ./...` passes (pre-existing vet warnings unrelated to this change)
- [x] Reproduced the scientific-notation output with a minimal Go program and verified the fix emits `32218272741`
- [ ] Verify on a real homer deployment that a search by large `id` (> 2^31) now uses the index and returns within seconds instead of minutes

## Notes

- Behaviour for the array element type is unchanged: this branch already asserted `float64` implicitly via `%v` on JSON-parsed numbers; the fix makes that assumption explicit with `val.(float64)`.
- Scope is intentionally minimal — this is a two-line change in hot-path SQL construction. Broader cleanups (parameter binding for `IN (...)`, `int` → `int64` for the single-id branch at lines 604 / 712) are left for a follow-up.

Related: #364 (interface conversion panic: not float64), which already pointed at this code path handling ids as `float64`.