### PR TITLE
fix: Escape username in filter ldap for group

### DIFF
--- a/utils/ldap/ldap.go
+++ b/utils/ldap/ldap.go
@@ -282,7 +282,7 @@ func (lc *LDAPClient) GetGroupsOfUser(username string) ([]string, error) {
 	searchRequest := ldap.NewSearchRequest(
 		lc.Base,
 		lc.ScopeValue, lc.DerefValue, lc.GroupLimit, lc.TimeLimit, false,
-		fmt.Sprintf(lc.GroupFilter, parsedUsername),
+		fmt.Sprintf(lc.GroupFilter, ldap.EscapeFilter(parsedUsername)),
 		lc.GroupAttribute,
 		nil,
 	)


### PR DESCRIPTION
```
Couldn't get any group for user test: LDAP Result Code 201 \"Filter Compile Error\": ldap: finished compiling filter with extra at end
```
Corrects  if the name (CN) contains special characters like **(** and more