### PR TITLE
Enable account on explicit LDAP group match

### DIFF
--- a/data/service/user.go
+++ b/data/service/user.go
@@ -249,9 +249,16 @@ func (us *UserService) LoginUser(username, password string) (string, model.Table
 			if len(groups) > 0 && heputils.ElementExists(groups, us.LdapClient.AdminGroup) {
 				logger.Debug("User ", username, " is a member of the admin group ", us.LdapClient.AdminGroup)
 				userData.IsAdmin = true
+				// A matched group means authentication succeeded, so the account
+				// must be marked enabled. Otherwise the controller's
+				// `if !userData.Enabled` check rejects the login with a 401 even
+				// though the user authenticated and matched a configured group.
+				userData.Enabled = true
 			} else if len(groups) > 0 && heputils.ElementExists(groups, us.LdapClient.UserGroup) {
 				logger.Debug("User ", username, " is a member of the user group ", us.LdapClient.UserGroup)
 				userData.IsAdmin = false
+				// Enable the account on a successful user-group match (see above).
+				userData.Enabled = true
 			} else {
 				if !userData.IsAdmin && us.LdapClient.UserMode {
 					logger.Debug("User ", username, " didn't match any group but still logged in as USER because UserMode is set to true.")


### PR DESCRIPTION
## Problem

When an LDAP user authenticates and explicitly matches the configured **admin group** or **user group**, login still fails with a `401 Unauthorized`, even though authentication and the group check both succeed.

The cause is in `data/service/user.go` (`LoginUser`). In the two explicit group-match branches, `userData.IsAdmin` is set but `userData.Enabled` is never set, so it keeps its zero value of `false`. The login controller then rejects the request:

```go
// controller/v1/user.go
if !userData.Enabled {
    // returns 401 Unauthorized
}
```

Notably, the fallback branch — where login is permitted via `UserMode`/`AdminMode` with **no** group match — already sets `userData.Enabled = true`. So the looser path worked while the stricter, explicit group-match path silently failed.

## Fix

Set `userData.Enabled = true` in both group-match branches, consistent with the existing fallback behaviour.

## Testing

Built from this branch and deployed in a container against a live LDAP/AD directory. Users matching the configured admin and user groups can now log in successfully; behaviour of the `UserMode`/`AdminMode` fallback paths is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)